### PR TITLE
Implement a basic recursive traversal function

### DIFF
--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -1,0 +1,39 @@
+var assert = require("assert");
+var types = require("./types");
+var Node = types.namedTypes.Node;
+var isArray = types.builtInTypes.array;
+
+function Path(node, parentPath) {
+    assert.ok(this instanceof Path);
+
+    Node.assert(node);
+
+    if (parentPath) {
+        assert.ok(parentPath instanceof Path);
+    } else {
+        parentPath = null;
+    }
+
+    Object.defineProperties(this, {
+        node: { value: node },
+        parent: { value: parentPath }
+    });
+}
+
+module.exports = function(node, callback) {
+    function traverse(node, parentPath) {
+        if (isArray.check(node)) {
+            node.map(function(child) {
+                traverse(child, parentPath);
+            });
+        } else if (Node.check(node)) {
+            var path = new Path(node, parentPath);
+            callback.call(path, node);
+            types.eachField(node, function(name, child) {
+                traverse(child, path);
+            });
+        }
+    }
+
+    traverse(node);
+};

--- a/main.js
+++ b/main.js
@@ -17,4 +17,5 @@ exports.namedTypes = types.namedTypes;
 exports.builders = types.builders;
 exports.getFieldValue = types.getFieldValue;
 exports.eachField = types.eachField;
+exports.traverse = require("./lib/traverse");
 exports.finalize = types.finalize;

--- a/test/run.js
+++ b/test/run.js
@@ -258,3 +258,45 @@ exports.testEachField = function(t, assert) {
 
     t.finish();
 };
+
+exports.testTraverse = function(t, assert) {
+    var traverse = types.traverse;
+
+    var call = b.expressionStatement(
+        b.callExpression(
+            b.memberExpression(
+                b.identifier("foo"),
+                b.identifier("bar"),
+                false
+            ),
+            [b.literal("baz")]
+        )
+    );
+
+    var ts = b.tryStatement(
+        b.blockStatement([call, call]),
+        b.catchClause(
+            b.identifier("err"),
+            null,
+            b.blockStatement([])
+        )
+    );
+
+    var literalCount = 0;
+
+    traverse(ts, function(node) {
+        if (n.Literal.check(node)) {
+            literalCount += 1;
+            assert.strictEqual(node.value, "baz");
+            assert.strictEqual(this.parent.node, call.expression);
+            assert.strictEqual(this.parent.parent.node, call);
+            assert.strictEqual(this.parent.parent.parent.node, ts.block);
+            assert.strictEqual(this.parent.parent.parent.parent.node, ts);
+            assert.strictEqual(this.parent.parent.parent.parent.parent, null);
+        }
+    });
+
+    assert.strictEqual(literalCount, 2);
+
+    t.finish();
+};


### PR DESCRIPTION
The `Path` object that serves as the `this` object within the `callback` allows upwards traversal of the AST, even when a node object appears more than once in the AST.
