### PR TITLE
resolve implicit dependency from advanced defs to core defs

### DIFF
--- a/def/e4x.js
+++ b/def/e4x.js
@@ -1,3 +1,4 @@
+require("./core");
 var types = require("../lib/types");
 var def = types.Type.def;
 var or = types.Type.or;

--- a/def/es6.js
+++ b/def/es6.js
@@ -1,3 +1,4 @@
+require("./core");
 var types = require("../lib/types");
 var def = types.Type.def;
 var or = types.Type.or;

--- a/def/mozilla.js
+++ b/def/mozilla.js
@@ -1,3 +1,4 @@
+require("./core");
 var types = require("../lib/types");
 var def = types.Type.def;
 var or = types.Type.or;

--- a/def/xjs.js
+++ b/def/xjs.js
@@ -1,3 +1,4 @@
+require("./core");
 var types = require("../lib/types");
 var def = types.Type.def;
 var or = types.Type.or;


### PR DESCRIPTION
Hi there,

thank you for that missing library for esprima escodegen!
I converted your module to AMD format and found a little quirk that might not come up in node but you might fix it as well.

The defs in mozilla and es6 and so on require to have the "Node" and some other defs already finalized (e.g. set in defCache). When loaded  per AMD the modules might be loaded in other order asynchron so that sometimes core.js is not finalized and another def-module tries to load the "Node" as a def, which gives an error (def is not defined in 553 of types.j

Would be so nice if you could merge it in, so that I can be up to date with your lib for updates.

Best regards
Philipp
