### PR TITLE
Handle more yield expression parent expression types that needs parens.

### DIFF
--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -172,6 +172,15 @@ NPp.needsParens = function() {
             || n.Property.check(parent)
             || n.ConditionalExpression.check(parent);
 
+    if (n.YieldExpression.check(node))
+        return isBinary(parent)
+            || n.CallExpression.check(parent)
+            || n.MemberExpression.check(parent)
+            || n.NewExpression.check(parent)
+            || n.ConditionalExpression.check(parent)
+            || n.UnaryExpression.check(parent)
+            || n.YieldExpression.check(parent);
+
     if (n.NewExpression.check(parent) &&
         this.name === "callee") {
         assert.strictEqual(parent.callee, node);
@@ -220,9 +229,6 @@ NPp.needsParens = function() {
     if (n.ObjectExpression.check(node) &&
         this.firstInStatement())
         return true;
-
-    if (n.YieldExpression.check(node))
-        return isBinary(parent);
 
     return false;
 };


### PR DESCRIPTION
Turns out there are a lot more parent expression types to handle:

``` javascript
var recast = require('recast');
var b = recast.types.builders;

var eg1 = b.callExpression(
  b.yieldExpression(
    b.literal(1), false
  ),
  []
);

console.log(recast.print(eg1).code)

var eg2 = b.memberExpression(
  b.yieldExpression(
    b.literal(1), false
  ),
  b.literal('prop'),
  true
);

console.log(recast.print(eg2).code)

var eg3 = b.newExpression(
  b.yieldExpression(
    b.literal(1), false
  ),
  []
);

console.log(recast.print(eg3).code)

var eg4 = b.conditionalExpression(
  b.yieldExpression(
    b.literal(1), false
  ),
  b.yieldExpression(
    b.literal(1), false
  ),
  b.yieldExpression(
    b.literal(1), false
  )
);

console.log(recast.print(eg4).code)


var eg5 = b.unaryExpression(
  '+',
  b.yieldExpression(
    b.literal(1), false
  ),
  true
);

console.log(recast.print(eg5).code)

var eg6 = b.yieldExpression(
  b.yieldExpression(
    b.literal(1), false
  ),
  false
);

console.log(recast.print(eg6).code)
```

Expected:

``` javascript
(yield 1)()
(yield 1)["prop"]
new (yield 1)()
((yield 1) ? (yield 1) : (yield 1))
+(yield 1)
yield (yield 1)
```

Actual:

``` javascript
yield 1()
yield 1["prop"]
new yield 1()
(yield 1 ? yield 1 : yield 1)
+yield 1
yield yield 1
```
