### PR TITLE
Update scope tracking module keyword support

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -44,11 +44,6 @@ var scopeTypes = [
     namedTypes.CatchClause
 ];
 
-if (namedTypes.ModuleDeclaration) {
-    // Include ModuleDeclaration only if it exists (ES6).
-    scopeTypes.push(namedTypes.ModuleDeclaration);
-}
-
 var ScopeType = Type.or.apply(Type, scopeTypes);
 
 Scope.isEstablishedBy = function(node) {
@@ -121,6 +116,10 @@ function recursiveScanScope(path, bindings) {
           node.name ? path.get("name") : path.get("id"),
           bindings
         );
+
+    } else if (namedTypes.ModuleDeclaration &&
+               namedTypes.ModuleDeclaration.check(node)) {
+        addPattern(path.get("id"), bindings);
 
     } else if (Node.check(node)) {
         types.eachField(node, function(name, child) {


### PR DESCRIPTION
The ES6 spec no longer includes "block-style" modules:

``` js
// gone!
module "foo" {}
```

However, it does include the "module instance import" form:

``` js
module foo from "foo";
```

This PR removes the former and adds the latter to scope tracking (so that `foo` is tracked in scope).
