### PR TITLE
NamedSpecifier wasn't defined to take null for name as intended

### DIFF
--- a/def/es6.js
+++ b/def/es6.js
@@ -112,7 +112,7 @@ def("Specifier").bases("Node");
 def("NamedSpecifier")
     .bases("Specifier")
     .field("id", def("Identifier"))
-    .field("name", def("Identifier"), defaults["null"]);
+    .field("name", or(def("Identifier"), null), defaults["null"]);
 
 def("ExportSpecifier")
     .bases("NamedSpecifier")


### PR DESCRIPTION
An import specifier can either have a name (alias) or not:

``` js
// both valid
import {foo as bar} from "foo";
import {foo} from "foo";
```

The definition for `NamedSpecifier` was set to default to null for the name, but wasn't defined to actually accept null as the value. This PR fixes the definition :)
