### PR TITLE
Fix ExportDeclaration field types and default values

### DIFF
--- a/def/es6.js
+++ b/def/es6.js
@@ -132,13 +132,13 @@ def("ExportDeclaration")
     .field("default", isBoolean)
     .field("declaration", or(
         def("Declaration"),
-        def("AssignmentExpression") // Implies default.
+        def("Expression") // Implies default.
     ))
     .field("specifiers", [or(
         def("ExportSpecifier"),
         def("ExportBatchSpecifier")
-    )])
-    .field("source", or(ModuleSpecifier, null));
+    )], defaults.emptyArray)
+    .field("source", or(ModuleSpecifier, null), defaults["null"]);
 
 def("ImportDeclaration")
     .bases("Declaration")


### PR DESCRIPTION
The main confusion here was that `AssignmentExpression` means something different in the spec from what it means in the AST type hierarchy, where it actually has to involve an assignment operator like `=` or `+=`. In the spec, an `AssignmentExpression` is just a slight restriction of the general `Expression` type, so that's what we should be using here.

Closes #28.
