### PR TITLE
Apply same paren rules to NewExpression as CallExpression

### DIFF
--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -122,8 +122,8 @@ NPp.needsParens = function() {
             && parent.object === node;
 
     if (isBinary(node)) {
-        if (n.CallExpression.check(parent) &&
-            this.name === "callee") {
+        if ((n.CallExpression.check(parent) || n.NewExpression.check(parent))
+            && this.name === "callee") {
             assert.strictEqual(parent.callee, node);
             return true;
         }


### PR DESCRIPTION
Before, this AST:

``` js
b.newExpression(
  b.logicalExpression(
    '||',
    b.identifier('One'),
    b.identifier('Two')
  ),
  [b.identifier('foo')]
);
```

would print as:

``` js
new One || Two(foo)
```

This fixes it to print as:

``` js
new (One || Two)(foo)
```

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benjamn/ast-types/pull/30%23issuecomment-39146170%22%2C%20%22https%3A//github.com/benjamn/ast-types/pull/30%23issuecomment-40671742%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benjamn/ast-types/pull/30%23issuecomment-39146170%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20audit%20the%20other%20places%20in%20this%20file%20where%20%60n.CallExpression.check%60%20is%20used%20and%20decide%20if%20those%20sites%20need%20a%20%60n.NewExpression.check%60%20too%3F%5Cr%5Cn%5Cr%5CnIf%20you%20think%20it%20helps%2C%20you%20can%20also%20create%20a%20kind%20of%20union%20type%3A%5Cr%5Cn%60%60%60js%5Cr%5Cnvar%20CallOrNewExpression%20%3D%20types.Type.or%28%5Cr%5Cn%20%20n.CallExpression%2C%5Cr%5Cn%20%20n.NewExpression%5Cr%5Cn%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cnand%20then%20do%20%60CallOrNewExpression.check%28node%29%60%20instead%20of%20%60n.CallExpression.check%28node%29%20%7C%7C%20n.NewExpression.check%28node%29%60.%22%2C%20%22created_at%22%3A%20%222014-03-31T21%3A45%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5750%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/benjamn%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28bump%29%22%2C%20%22created_at%22%3A%20%222014-04-17T01%3A28%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5750%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/benjamn%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benjamn/ast-types/pull/30#issuecomment-39146170'>General Comment</a></b>
- <a href='https://github.com/benjamn'><img border=0 src='https://avatars.githubusercontent.com/u/5750?v=3' height=16 width=16'></a> Can you audit the other places in this file where `n.CallExpression.check` is used and decide if those sites need a `n.NewExpression.check` too?
  If you think it helps, you can also create a kind of union type:

``` js
var CallOrNewExpression = types.Type.or(
n.CallExpression,
n.NewExpression
);
```

and then do `CallOrNewExpression.check(node)` instead of `n.CallExpression.check(node) || n.NewExpression.check(node)`.
- <a href='https://github.com/benjamn'><img border=0 src='https://avatars.githubusercontent.com/u/5750?v=3' height=16 width=16'></a> (bump)

<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/30?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/30?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benjamn/ast-types/pull/30'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
