### PR TITLE
Ensure that the sequence in `a = (1, 2)` believes it needs parens.

### DIFF
--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -162,7 +162,8 @@ NPp.needsParens = function() {
             || n.MemberExpression.check(parent)
             || n.ArrayExpression.check(parent)
             || n.Property.check(parent)
-            || n.ConditionalExpression.check(parent);
+            || n.ConditionalExpression.check(parent)
+            || n.AssignmentExpression.check(parent);
 
     if (n.YieldExpression.check(node))
         return isBinary(parent)

--- a/test/run.js
+++ b/test/run.js
@@ -479,6 +479,15 @@ describe("NodePath", function() {
         assert.ok(!byPath.get("expression").needsParens());
         assert.ok(byPath.get("expression", "left").needsParens());
         assert.ok(byPath.get("expression", "right").needsParens());
+
+        var sequenceAssignmentAST = b.assignmentExpression(
+          '=',
+          b.identifier('a'),
+          b.sequenceExpression([b.literal(1), b.literal(2)])
+        );
+
+        var sequenceAssignmentPath = new NodePath(sequenceAssignmentAST);
+        assert.ok(sequenceAssignmentPath.get("right").needsParens());
     });
 });
 


### PR DESCRIPTION
Otherwise you end up with `a = 1, 2` when recast prints the AST.
