### PR TITLE
Ensure that function expressions with ids bind their id inside.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -94,7 +94,12 @@ function scanScope(path, bindings) {
 function recursiveScanScope(path, bindings) {
     var node = path.value;
 
-    if (isArray.check(node)) {
+    if (path.parent &&
+        namedTypes.FunctionExpression.check(path.parent.node) &&
+        path.parent.node.id) {
+        addPattern(path.parent.get("id"), bindings);
+
+    } else if (isArray.check(node)) {
         path.each(function(childPath) {
             recursiveScanChild(childPath, bindings);
         });

--- a/test/run.js
+++ b/test/run.js
@@ -555,21 +555,30 @@ describe("scope.getBindings", function () {
         "var foo = 42;",
         "function bar(baz) {",
         "  return baz + foo;",
-        "}"
+        "}",
+        "var nom = function rom(pom) {",
+        "  return rom(pom);",
+        "};"
     ];
 
     var ast = parse(scope.join("\n"));
     it("should get local and global scope bindings", function() {
         traverse(ast, function(node) {
+            var bindings;
             if (n.Program.check(node)) {
-                var bindings = this.scope.getBindings();
-                assert.deepEqual(["bar", "foo"], Object.keys(bindings).sort());
+                bindings = this.scope.getBindings();
+                assert.deepEqual(["bar", "foo", "nom"], Object.keys(bindings).sort());
                 assert.equal(1, bindings.foo.length);
                 assert.equal(1, bindings.bar.length);
             } else if (n.FunctionDeclaration.check(node)) {
-                var bindings = this.scope.getBindings();
+                bindings = this.scope.getBindings();
                 assert.deepEqual(["baz"], Object.keys(bindings));
                 assert.equal(1, bindings.baz.length);
+            } else if (n.ReturnStatement.check(node) &&
+                       n.Identifier.check(node.argument) &&
+                       node.argument.name === "rom") {
+                bindings = this.scope.getBindings();
+                assert.deepEqual(["pom", "rom"], Object.keys(bindings).sort());
             }
         });
     });


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope:

> (With a function expression,) The function name can be used only
> within the function's body. Attempting to use it outside the
> function's body results in an error (or undefined if the function name
> was previously declared via a var statement).
