### PR TITLE
Ensure replacing a node with itself works consistently.

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -121,15 +121,32 @@ Pp.replace = function(replacement) {
     var results = [];
 
     if (toString.call(parentValue) === arrayToString) {
+        var i;
+        var newIndex;
+
+        if (this.value !== parentCache[name].value) {
+            // Something caused our index (name) to become out of date.
+            for (i = 0; i < parentValue.length; ++i) {
+                if (parentValue[i] === this.value) {
+                    this.name = name = i;
+                    break;
+                }
+            }
+            assert.ok(
+                this.value === parentCache[name].value,
+                "Cannot replace already replaced node: " + this.value.type
+            );
+        }
+
         delete parentCache.length;
         delete parentCache[name];
 
         var moved = {};
 
-        for (var i = name + 1; i < parentValue.length; ++i) {
+        for (i = name + 1; i < parentValue.length; ++i) {
             var child = parentCache[i];
             if (child) {
-                var newIndex = i - 1 + count;
+                newIndex = i - 1 + count;
                 moved[newIndex] = child;
                 Object.defineProperty(child, "name", { value: newIndex });
                 delete parentCache[i];


### PR DESCRIPTION
This comes from a desire to prepend variables at the top of a scope. I [asked on twitter how to achieve this](https://twitter.com/eventualbuddha/status/458994449410834432) since using `Array#unshift` to prepend caused subsequent `replace` calls for any of the `NodePath` inside the same array to replace the wrong node. The [solution proposed by @benjamn](https://twitter.com/benjamn/status/459001056861904897) works as long as you aren't traversing and holding on to a stale copy of the `NodePath` with the wrong index (name).

This commit ensures that the stale `NodePath` is updated with the right index (name) so that if you call `this.replace(...)` inside your traversal callback you will be replacing the right node.
