### PR TITLE
Fix AwaitExpression all field default value

### DIFF
--- a/def/es7.js
+++ b/def/es7.js
@@ -32,4 +32,4 @@ def("AwaitExpression")
     .bases("Expression")
     .build("argument", "all")
     .field("argument", or(def("Expression"), null))
-    .field("all", isBoolean, false);
+    .field("all", isBoolean, defaults["false"]);


### PR DESCRIPTION
Corrects the same error that was fixed in 759363c76ab7950081916b08c8dae8fab6e475e9 for YieldExpression
