### PR TITLE
Make Path.prototype.replace reuse replaced Path objects

### DIFF
--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -18,6 +18,7 @@ Object.defineProperties(NPp, {
     node: {
         get: function() {
             Object.defineProperty(this, "node", {
+                configurable: true, // Enable deletion.
                 value: this._computeNode()
             });
 
@@ -28,6 +29,7 @@ Object.defineProperties(NPp, {
     parent: {
         get: function() {
             Object.defineProperty(this, "parent", {
+                configurable: true, // Enable deletion.
                 value: this._computeParent()
             });
 
@@ -38,6 +40,7 @@ Object.defineProperties(NPp, {
     scope: {
         get: function() {
             Object.defineProperty(this, "scope", {
+                configurable: true, // Enable deletion.
                 value: this._computeScope()
             });
 
@@ -45,6 +48,13 @@ Object.defineProperties(NPp, {
         }
     }
 });
+
+NPp.replace = function() {
+    delete this.node;
+    delete this.parent;
+    delete this.scope;
+    return Path.prototype.replace.apply(this, arguments);
+};
 
 // The value of the first ancestor Path whose value is a Node.
 NPp._computeNode = function() {

--- a/lib/path.js
+++ b/lib/path.js
@@ -30,7 +30,7 @@ function Path(value, parentPath, name) {
 
     // Calling path.get("child") multiple times always returns the same
     // child Path object, for both performance and consistency reasons.
-    this.__childCache = {};
+    this.__childCache = Object.create(null);
 }
 
 var Pp = Path.prototype;
@@ -114,76 +114,91 @@ Pp.filter = function(callback, context) {
 };
 
 Pp.replace = function(replacement) {
-    var count = arguments.length;
-
-    assert.ok(
-        this.parentPath instanceof Path,
-        "Instead of replacing the root of the tree, create a new tree."
-    );
-
-    var name = this.name;
+    var results = [];
     var parentValue = this.parentPath.value;
     var parentCache = this.parentPath.__childCache;
-    var results = [];
+    var count = arguments.length;
+
+    assert.strictEqual(
+        parentCache[this.name] || this, this,
+        "Cannot replace an already-replaced path"
+    );
+
+    assert.strictEqual(
+        parentValue[this.name], this.value,
+        "Cannot replace an already-replaced path"
+    );
 
     if (toString.call(parentValue) === arrayToString) {
-        var i;
-        var newIndex;
+        var originalLength = parentValue.length;
+        var moved = Object.create(null);
 
-        if (this.value !== parentCache[name].value) {
-            // Something caused our index (name) to become out of date.
-            for (i = 0; i < parentValue.length; ++i) {
-                if (parentValue[i] === this.value) {
-                    this.name = name = i;
-                    break;
-                }
-            }
-            assert.ok(
-                this.value === parentCache[name].value,
-                "Cannot replace already replaced node: " + this.value.type
-            );
-        }
-
-        delete parentCache.length;
-        delete parentCache[name];
-
-        var moved = {};
-
-        for (i = name + 1; i < parentValue.length; ++i) {
-            var child = parentCache[i];
-            if (child) {
-                newIndex = i - 1 + count;
-                moved[newIndex] = child;
-                Object.defineProperty(child, "name", { value: newIndex });
+        for (var i = this.name + 1; i < originalLength; ++i) {
+            if (hasOwn.call(parentCache, i)) {
+                var childPath = parentCache[i];
+                var newIndex = i - 1 + count;
+                moved[newIndex] = childPath;
+                childPath.name = newIndex;
                 delete parentCache[i];
             }
         }
 
-        var args = slice.call(arguments);
-        args.unshift(name, 1);
-        parentValue.splice.apply(parentValue, args);
+        delete parentCache.length;
 
-        for (newIndex in moved) {
-            if (hasOwn.call(moved, newIndex)) {
-                parentCache[newIndex] = moved[newIndex];
-            }
+        var spliceArgs = [this.name, 1];
+        for (i = 0; i < count; ++i) {
+            spliceArgs.push(arguments[i]);
         }
 
-        for (i = name; i < name + count; ++i) {
-            results.push(this.parentPath.get(i));
+        var splicedOut = parentValue.splice.apply(parentValue, spliceArgs);
+
+        assert.strictEqual(splicedOut[0], this.value);
+        assert.strictEqual(
+            parentValue.length,
+            originalLength - 1 + count
+        );
+
+        for (newIndex in moved) {
+            parentCache[newIndex] = moved[newIndex];
+        }
+
+        if (count === 0) {
+            delete this.value;
+            delete parentCache[this.name];
+            this.__childCache = {};
+
+        } else {
+            assert.strictEqual(parentValue[this.name], replacement);
+
+            if (this.value !== replacement) {
+                this.value = replacement;
+                this.__childCache = {};
+            }
+
+            for (i = 0; i < count; ++i) {
+                results.push(this.parentPath.get(this.name + i));
+            }
+
+            assert.strictEqual(results[0], this);
         }
 
     } else if (count === 1) {
-        delete parentCache[name];
-        parentValue[name] = replacement;
-        results.push(this.parentPath.get(name));
+        if (this.value !== replacement) {
+            this.__childCache = {};
+        }
+        this.value = parentValue[this.name] = replacement;
+        results.push(this);
 
     } else if (count === 0) {
-        delete parentCache[name];
-        delete parentValue[name];
+        delete parentValue[this.name];
+        delete this.value;
+        this.__childCache = {};
+
+        // Leave this path cached as parentCache[this.name], even though
+        // it no longer has a value defined.
 
     } else {
-        assert.ok(false, "Could not replace Path.");
+        assert.ok(false, "Could not replace path");
     }
 
     return results;

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -35,7 +35,10 @@ function traverseWithFullPathInfo(node, callback) {
             if (callback.call(path, value, traverse) === false) {
                 return;
             }
-        } else if (!isObject.check(value)) {
+        }
+
+        value = path.value;
+        if (!isObject.check(value)) {
             return;
         }
 


### PR DESCRIPTION
This mitigates a significant source of ongoing confusion, namely that it was previously difficult to replace the same path twice unless you were very careful to call `path.replace(newNode)[0].replace` instead of trying to call `path.replace` again.

Although I believe this will fix a number of subtle bugs, it still calls for a minor version bump because it's potentially a breaking change.
