### PR TITLE
Warn about bogus/typo'd visitor methods

### DIFF
--- a/lib/path-visitor.js
+++ b/lib/path-visitor.js
@@ -19,7 +19,17 @@ function computeMethodNameTable(visitor) {
 
     for (var methodName in visitor) {
         if (/^visit[A-Z]/.test(methodName)) {
-            typeNames[methodName.slice("visit".length)] = true;
+            var type = methodName.slice("visit".length);
+
+            if (!(type in types.namedTypes)) {
+                console.warn(
+                        "\033[33m", // yellow
+                        "Are you sure you meant [" + methodName + "]?",
+                        "\033[0m" // reset
+                );
+            } else {
+                typeNames[type] = true;
+            }
         }
     }
 

--- a/test/run.js
+++ b/test/run.js
@@ -1142,6 +1142,13 @@ describe("types.visit", function() {
 
         assert.deepEqual(objProp.property.arguments, []);
     });
+
+    it("should complain about non-existent node types", function() {
+        types.visit(objProp, {
+            visitFunctoin: function(path) {}
+        });
+    });
+
 });
 
 describe("path.shift", function() {


### PR DESCRIPTION
An attempt to fix https://github.com/benjamn/ast-types/issues/44.

Not sure the best way to test (or if we want to) a `console.warn` here without some funky stubbing business?
