### PR TITLE
Fix a few small issues I found in ast-types definitions:

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -251,8 +251,7 @@ def("AssignmentExpression")
     .bases("Expression")
     .build("operator", "left", "right")
     .field("operator", AssignmentOperator)
-    // TODO Shouldn't this be def("Pattern")?
-    .field("left", def("Expression"))
+    .field("left", def("Pattern"))
     .field("right", def("Expression"));
 
 var UpdateOperator = or("++", "--");

--- a/def/es6.js
+++ b/def/es6.js
@@ -11,7 +11,7 @@ var defaults = require("../lib/shared").defaults;
 def("Function")
     .field("generator", isBoolean, defaults["false"])
     .field("expression", isBoolean, defaults["false"])
-    .field("defaults", [def("Expression")], defaults.emptyArray)
+    .field("defaults", [or(def("Expression"), null)], defaults.emptyArray)
     // TODO This could be represented as a SpreadElementPattern in .params.
     .field("rest", or(def("Identifier"), null), defaults["null"]);
 
@@ -112,8 +112,14 @@ def("SpreadElementPattern")
 var ClassBodyElement = or(
     def("MethodDefinition"),
     def("VariableDeclarator"),
-    def("ClassPropertyDefinition")
+    def("ClassPropertyDefinition"),
+    def("ClassProperty")
 );
+
+def("ClassProperty")
+  .bases("Declaration")
+  .build("id")
+  .field("id", def("Identifier"));
 
 def("ClassPropertyDefinition") // static property
     .bases("Declaration")


### PR DESCRIPTION
1) The left side of an assignment really should be a pattern. The SpiderMonkey
API does seem to be wrong here. Esprima will return a pattern for the left side
of the assignment. For example:

> esprima.parse("[a,b] = [1,2]").body[0].expression.left.type
>   "ArrayPattern"

2) I believe the holes in the defaults array in a function definition should be
represented by null. This seems more consistant with other places where a node
is missing. However the SpiderMonkey API doesn't allow for null and Esprima
will use undefined. This change just makes the definition a little more general
to support null if a parser were to return that.

3) Adding `ClassProperty` to the AST. This is for parsing things like
typescript class properties. Facebook's fork of Esprima's harmony branch
supports this with the ClassProperty node:
https://github.com/facebook/esprima/blob/fb-harmony/esprima.js#L2144

This is for code like

  class Foo {
    bar: string;
  }
