### PR TITLE
Scope: injectTemporary

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -5,6 +5,7 @@ var namedTypes = types.namedTypes;
 var Node = namedTypes.Node;
 var isArray = types.builtInTypes.array;
 var hasOwn = Object.prototype.hasOwnProperty;
+var b = types.builders;
 
 function Scope(path, parentScope) {
     assert.ok(this instanceof Scope);
@@ -80,6 +81,24 @@ Sp.declareTemporary = function(prefix) {
 
     var name = prefix + index;
     return this.bindings[name] = types.builders.identifier(name);
+};
+
+Sp.injectTemporary = function(identifier, init) {
+    identifier || (identifier = this.declareTemporary());
+
+    var bodyPath = this.path.get("body");
+    if (namedTypes.BlockStatement.check(bodyPath.value)) {
+        bodyPath = bodyPath.get("body");
+    }
+
+    bodyPath.unshift(
+        b.variableDeclaration(
+            "var",
+            [b.variableDeclarator(identifier, init || null)]
+        )
+    );
+
+    return identifier;
 };
 
 Sp.scan = function(force) {

--- a/test/run.js
+++ b/test/run.js
@@ -762,6 +762,29 @@ describe("scope methods", function () {
         });
     });
 
+    it("should inject temporary into current scope", function() {
+        var ast = parse(scope.join("\n"));
+        var bindings;
+
+        types.visit(ast, {
+            visitProgram: function(path) {
+                path.scope.injectTemporary();
+                bindings = path.scope.getBindings();
+                assert.deepEqual(["bar", "foo", "nom", "t$0$0"], Object.keys(bindings).sort());
+                this.traverse(path);
+            },
+
+            visitFunctionDeclaration: function(path) {
+                path.scope.injectTemporary(
+                    path.scope.declareTemporary("t$")
+                )
+                bindings = path.scope.getBindings();
+                assert.deepEqual(["baz", "t$1$0"], Object.keys(bindings));
+                this.traverse(path);
+            }
+        });
+    });
+
     it("declareTemporary should use distinct names in nested scopes", function() {
         var ast = parse(scope.join("\n"));
         var globalVarDecl;


### PR DESCRIPTION
Automatically injects a temp variable into the current scope. If identifiers is
not passed, creates one by default.
