### PR TITLE
Allow ImportDeclaration kind to be undefined.

### DIFF
--- a/def/es6.js
+++ b/def/es6.js
@@ -184,7 +184,7 @@ def("ImportDeclaration")
     .bases("Declaration")
     .build("specifiers", "kind", "source")
     .field("specifiers", [def("ImportSpecifier")])
-    .field("kind", or("named", "default"))
+    .field("kind", or("named", "default", null))
     .field("source", ModuleSpecifier);
 
 def("TaggedTemplateExpression")


### PR DESCRIPTION
For example, given `import "foo";` the `kind` property of that node will be `undefined`. I'm not sure using `null` is the appropriate way to model this.

I ran into this because I have a script that I'm using to generate JSDoc for all the AST types for WebStorm and it complained that comparing `ImportDeclaration#kind` to `undefined` did not make sense because it had to be a string. This is the relevant part of the generated doc code:

``` js
/**
 * @constructor
 * @extends AST.Declaration
 */
AST.ImportDeclaration = function(){};

/**
 * @type {AST.ImportSpecifier[]}
 */
AST.ImportDeclaration.prototype.specifiers;

/**
 * @type {string}
 */
AST.ImportDeclaration.prototype.kind;

/**
 * @type {AST.Literal}
 */
AST.ImportDeclaration.prototype.source;
```

Which comes from this:

``` js
def("ImportDeclaration")
    .bases("Declaration")
    .build("specifiers", "kind", "source")
    .field("specifiers", [def("ImportSpecifier")])
    .field("kind", or("named", "default"))
    .field("source", ModuleSpecifier);
```

With this patch applied the type signature would change to `@type {?string}`, but that doesn't actually make WebStorm happy either. Really it should be `@type {string=}` or `@type {string | undefined}`.
