### PR TITLE
Fix bindings in named function expressions

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -139,8 +139,9 @@ function recursiveScanScope(path, bindings) {
         namedTypes.FunctionExpression.check(path.parent.node) &&
         path.parent.node.id) {
         addPattern(path.parent.get("id"), bindings);
+    }
 
-    } else if (!node) {
+    if (!node) {
         // None of the remaining cases matter if node is falsy.
 
     } else if (isArray.check(node)) {

--- a/test/run.js
+++ b/test/run.js
@@ -735,6 +735,7 @@ describe("scope methods", function () {
         "  return baz + foo;",
         "}",
         "var nom = function rom(pom) {",
+        "  var zom;",
         "  return rom(pom);",
         "};"
     ];
@@ -760,7 +761,8 @@ describe("scope methods", function () {
                        n.CallExpression.check(node.argument) &&
                        node.argument.callee.name === "rom") {
                 bindings = this.scope.getBindings();
-                assert.deepEqual(["pom", "rom"], Object.keys(bindings).sort());
+                assert.deepEqual(["pom", "rom", "zom"], Object.keys(bindings).sort());
+                checked.push(node);
             }
         });
 


### PR DESCRIPTION
The commit that added support for function expression names counting as part of the binding for that function’s scope, 9068526614db5859e00037eafbcb09715fb3b703, caused _only_ the function name to count as a binding in that function. For example:

``` js
var f = function f(a, b) { var c; };
```

Inside `f`, the only bound name was `f` itself referring to the function expression. It should have bound `a`, `b`, `c`, and `f`.
