### PR TITLE
Amend type annotation fields to core node types in fb-harmony.js

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -109,7 +109,7 @@ def("TypeAnnotatedIdentifier")
 
 def("TypeAnnotation")
     .bases("Pattern")
-    .build("annotatedType", "templateTypes", "paramTypes", "returnType", 
+    .build("annotatedType", "templateTypes", "paramTypes", "returnType",
            "unionType", "nullable")
     .field("annotatedType", def("Identifier"))
     .field("templateTypes", or([def("TypeAnnotation")], null))
@@ -117,3 +117,12 @@ def("TypeAnnotation")
     .field("returnType", or(def("TypeAnnotation"), null))
     .field("unionType", or(def("TypeAnnotation"), null))
     .field("nullable", isBoolean);
+
+def("Identifier")
+    .field("annotation", or(def("TypeAnnotation"), null), defaults['null']);
+
+def("Function")
+    .field("returnType", or(def("TypeAnnotation"), null), defaults['null']);
+
+def("ClassProperty")
+    .field("id", or(def("Identifier"), def("TypeAnnotatedIdentifier")));


### PR DESCRIPTION
This is likely to change a bit in the future (the flow parser doesn't use the exact same AST structure as what esprima-fb has right at the moment), but for now we need to understand these fields so we can build out a Recast transform that strips Flow type annotations
