### PR TITLE
Consider object and array patterns for scope

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -215,7 +215,8 @@ def("Property")
     .build("kind", "key", "value")
     .field("kind", or("init", "get", "set"))
     .field("key", or(def("Literal"), def("Identifier")))
-    .field("value", def("Expression"));
+    // esprima allows Pattern
+    .field("value", or(def("Expression"), def("Pattern")));
 
 def("SequenceExpression")
     .bases("Expression")
@@ -317,7 +318,8 @@ def("ObjectPattern")
     .bases("Pattern")
     .build("properties")
     // TODO File a bug to get PropertyPattern added to the interfaces API.
-    .field("properties", [def("PropertyPattern")]);
+    // esprima uses Property
+    .field("properties", [or(def("PropertyPattern"), def("Property"))]);
 
 def("PropertyPattern")
     .bases("Pattern")

--- a/def/es6.js
+++ b/def/es6.js
@@ -103,6 +103,14 @@ def("SpreadElementPattern")
     .build("argument")
     .field("argument", def("Pattern"));
 
+def("ArrayPattern")
+    .field("elements", [or(
+      def("Pattern"),
+      null,
+      // used by esprima
+      def("SpreadElement")
+    )]);
+
 var ClassBodyElement = or(
     def("MethodDefinition"),
     def("VariableDeclarator"),

--- a/def/es7.js
+++ b/def/es7.js
@@ -25,7 +25,10 @@ def("SpreadPropertyPattern")
 def("ObjectPattern")
     .field("properties", [or(
         def("PropertyPattern"),
-        def("SpreadPropertyPattern")
+        def("SpreadPropertyPattern"),
+        // used by esprima
+        def("Property"),
+        def("SpreadProperty")
     )]);
 
 def("AwaitExpression")

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -225,10 +225,36 @@ function addPattern(patternPath, bindings) {
         } else {
             bindings[pattern.name] = [patternPath];
         }
+    } else if (namedTypes.ObjectPattern.check(pattern)) {
 
-    } else if (namedTypes.SpreadElement &&
-               namedTypes.SpreadElement.check(pattern)) {
-        addPattern(patternPath.get("argument"), bindings);
+        patternPath.get('properties').each(function(propertyPath) {
+            var property = propertyPath.value;
+            if (namedTypes.Pattern.check(property)) {
+                addPattern(propertyPath, bindings);
+            } else  if (namedTypes.Property.check(property)) {
+                addPattern(propertyPath.get('value'), bindings);
+            } else if (namedTypes.SpreadProperty &&
+                       namedTypes.SpreadProperty.check(property)) {
+                addPattern(propertyPath.get('argument'), bindings);
+            }
+        });
+    } else if (namedTypes.ArrayPattern.check(pattern)) {
+        patternPath.get('elements').each(function(elementPath) {
+            var element = elementPath.value;
+            if (namedTypes.Pattern.check(element)) {
+              addPattern(elementPath, bindings);
+            } else if (namedTypes.SpreadElement &&
+                       namedTypes.SpreadElement.check(element)) {
+                addPattern(elementPath.get("argument"), bindings);
+            }
+        });
+    } else if (namedTypes.PropertyPattern.check(pattern)) {
+        addPattern(patternPath.get('pattern'), bindings);
+    } else if (namedTypes.SpreadElementPattern &&
+               namedTypes.SpreadElementPattern.check(pattern) ||
+               namedTypes.SpreadPropertyPattern &&
+               namedTypes.SpreadPropertyPattern.check(pattern)) {
+        addPattern(patternPath.get('argument'), bindings);
     }
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -1016,6 +1016,133 @@ describe("catch block scope", function() {
     });
 });
 
+describe("array and object pattern scope", function() {
+
+    function scopeFromPattern(pattern) {
+        return new NodePath(
+            b.program([
+                b.variableDeclaration('var', [
+                    b.variableDeclarator(pattern, null)
+                ])
+            ])
+        ).scope;
+    }
+
+    // ObjectPattern with Property and SpreadProperty
+    // ArrayPattern with SpreadElement
+    describe("esprima", function() {
+        var objectPattern;
+        var arrayPattern;
+
+        beforeEach(function() {
+            // {a, b: c, ...d}
+            objectPattern = b.objectPattern([
+              b.property('init', b.identifier('a'), b.identifier('a')),
+              b.property('init', b.identifier('b'), b.identifier('c')),
+              b.spreadProperty(b.identifier('d')),
+            ]);
+
+            // [foo, bar, ...baz]
+            arrayPattern = b.arrayPattern([
+              b.identifier('foo'),
+              b.identifier('bar'),
+              b.spreadElement(b.identifier('baz'))
+            ]);
+        });
+
+        it("should handle object patterns variable declarations", function() {
+            var scope = scopeFromPattern(objectPattern);
+
+            assert.strictEqual(scope.declares("a"), true);
+            assert.strictEqual(scope.declares("b"), false);
+            assert.strictEqual(scope.declares("c"), true);
+            assert.strictEqual(scope.declares("d"), true);
+        });
+
+        it("should handle array patterns in variable declarations", function() {
+            var scope = scopeFromPattern(arrayPattern);
+
+            assert.strictEqual(scope.declares("foo"), true);
+            assert.strictEqual(scope.declares("bar"), true);
+            assert.strictEqual(scope.declares("baz"), true);
+        });
+
+        it("should handle nested patterns in variable declarations", function() {
+            // {a, b: c, ...d, e: [foo, bar, ...baz]}
+            objectPattern.properties.push(
+                b.property('init', b.identifier('e'), arrayPattern)
+            );
+
+            var scope = scopeFromPattern(objectPattern);
+            assert.strictEqual(scope.declares("a"), true);
+            assert.strictEqual(scope.declares("b"), false);
+            assert.strictEqual(scope.declares("c"), true);
+            assert.strictEqual(scope.declares("d"), true);
+            assert.strictEqual(scope.declares("e"), false);
+            assert.strictEqual(scope.declares("foo"), true);
+            assert.strictEqual(scope.declares("bar"), true);
+            assert.strictEqual(scope.declares("baz"), true);
+        });
+    });
+
+    // ObjectPattern with PropertyPattern and SpreadPropertyPattern
+    // ArrayPatterhn with SpreadElementPattern
+    describe("Mozilla Parser API", function() {
+        var objectPattern;
+        var arrayPattern;
+
+        beforeEach(function() {
+            // {a, b: c, ...d}
+            objectPattern = b.objectPattern([
+              b.propertyPattern(b.identifier('a'), b.identifier('a')),
+              b.propertyPattern(b.identifier('b'), b.identifier('c')),
+              b.spreadPropertyPattern(b.identifier('d')),
+            ]);
+
+            // [foo, bar, ...baz]
+            arrayPattern = b.arrayPattern([
+              b.identifier('foo'),
+              b.identifier('bar'),
+              b.spreadElementPattern(b.identifier('baz'))
+            ]);
+        });
+
+        it("should handle object patterns variable declarations", function() {
+            var scope = scopeFromPattern(objectPattern);
+
+            assert.strictEqual(scope.declares("a"), true);
+            assert.strictEqual(scope.declares("b"), false);
+            assert.strictEqual(scope.declares("c"), true);
+            assert.strictEqual(scope.declares("d"), true);
+        });
+
+        it("should handle array patterns in variable declarations", function() {
+            var scope = scopeFromPattern(arrayPattern);
+
+            assert.strictEqual(scope.declares("foo"), true);
+            assert.strictEqual(scope.declares("bar"), true);
+            assert.strictEqual(scope.declares("baz"), true);
+        });
+
+        it("should handle nested patterns in variable declarations", function() {
+            // {a, b: c, ...d, e: [foo, bar, ...baz]}
+            objectPattern.properties.push(
+                b.propertyPattern(b.identifier('e'), arrayPattern)
+            );
+
+            var scope = scopeFromPattern(objectPattern);
+            assert.strictEqual(scope.declares("a"), true);
+            assert.strictEqual(scope.declares("b"), false);
+            assert.strictEqual(scope.declares("c"), true);
+            assert.strictEqual(scope.declares("d"), true);
+            assert.strictEqual(scope.declares("e"), false);
+            assert.strictEqual(scope.declares("foo"), true);
+            assert.strictEqual(scope.declares("bar"), true);
+            assert.strictEqual(scope.declares("baz"), true);
+        });
+    });
+});
+
 describe("types.defineMethod", function() {
     function at(loc) {
         types.namedTypes.SourceLocation.assert(loc);


### PR DESCRIPTION
Currently, using an object pattern like

    var {foo, bar} = baz;

does not add `foo` and `bar` to the scope.

This change adds support for these patterns and extends the current type definitions to make them compatible with esprima. I hope this OK.

I believe there is a deviation from the Mozilla Parser API. Even though `PropertyPattern` is not officially defined, its signature in [`ObjectPattern`](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API#Patterns) looks like `{ key: ..., value: ... }` whereas ast-types uses `{key: ..., pattern: ... }`.

