### PR TITLE
feat(NodePath.prune): deal with an IfStatement not having its consequent...

### DIFF
--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var types = require("./types");
 var n = types.namedTypes;
+var b = types.builders;
 var isNumber = types.builtInTypes.number;
 var isArray = types.builtInTypes.array;
 var Path = require("./path");
@@ -61,33 +62,7 @@ NPp.prune = function() {
 
     this.replace();
 
-    if (n.VariableDeclaration.check(remainingNodePath.node)) {
-        var declarations = remainingNodePath.get('declarations').value;
-        if (!declarations || declarations.length === 0) {
-            return remainingNodePath.prune();
-        }
-    } else if (n.ExpressionStatement.check(remainingNodePath.node)) {
-        if (!remainingNodePath.get('expression').value) {
-            return remainingNodePath.prune();
-        }
-    } else if (n.IfStatement.check(remainingNodePath.node)) {
-        var testExpression = remainingNodePath.get('test').value;
-        var alternate = remainingNodePath.get('alternate').value;
-        var consequent = remainingNodePath.get('consequent').value;
-
-        if (!consequent && !alternate) {
-            var testExpressionStatement = types.builders.expressionStatement(testExpression);
-
-            remainingNodePath.replace(testExpressionStatement);
-        } else if (!consequent && alternate) {
-           var negatedTestExpression = types.builders.unaryExpression('!', testExpression, true);
-           var modifiedIfStatement = types.builders.ifStatement(negatedTestExpression, alternate);
-
-           remainingNodePath.replace(modifiedIfStatement);
-        }
-    }
-
-    return remainingNodePath;
+    return cleanUpNodesAfterPrune(remainingNodePath);
 };
 
 // The value of the first ancestor Path whose value is a Node.
@@ -406,6 +381,48 @@ function firstInStatement(path) {
     }
 
     return true;
+}
+
+/**
+ * Pruning certain nodes will result in empty or incomplete nodes, here we clean those nodes up.
+ */
+function cleanUpNodesAfterPrune(remainingNodePath) {
+    if (n.VariableDeclaration.check(remainingNodePath.node)) {
+        var declarations = remainingNodePath.get('declarations').value;
+        if (!declarations || declarations.length === 0) {
+            return remainingNodePath.prune();
+        }
+    } else if (n.ExpressionStatement.check(remainingNodePath.node)) {
+        if (!remainingNodePath.get('expression').value) {
+            return remainingNodePath.prune();
+        }
+    } else if (n.IfStatement.check(remainingNodePath.node)) {
+        cleanUpIfStatementAfterPrune(remainingNodePath);
+    }
+
+    return remainingNodePath;
+}
+
+function cleanUpIfStatementAfterPrune(ifStatement) {
+    var testExpression = ifStatement.get('test').value;
+    var alternate = ifStatement.get('alternate').value;
+    var consequent = ifStatement.get('consequent').value;
+
+    if (!consequent && !alternate) {
+        var testExpressionStatement = b.expressionStatement(testExpression);
+
+        ifStatement.replace(testExpressionStatement);
+    } else if (!consequent && alternate) {
+        var negatedTestExpression = b.unaryExpression('!', testExpression, true);
+
+        if (n.UnaryExpression.check(testExpression) && testExpression.operator === '!') {
+            negatedTestExpression = testExpression.argument;
+        }
+
+        ifStatement.get("test").replace(negatedTestExpression);
+        ifStatement.get("consequent").replace(alternate);
+        ifStatement.get("alternate").replace();
+    }
 }
 
 module.exports = NodePath;

--- a/test/run.js
+++ b/test/run.js
@@ -595,8 +595,6 @@ describe("NodePath", function() {
 
     it("should modify if statement node if consequent is pruned and alternate remains", function() {
         var programPath = new NodePath(parse("if(x > 10){var t = 0;}else{var f = 2;}"));
-        var testNodePath = programPath.get("body", 0, "test");
-        var alternateNodePath = programPath.get("body", 0, "alternate");
         var consequentNodePath = programPath.get("body", 0, "consequent");
 
         n.BlockStatement.assert(consequentNodePath.node);
@@ -609,8 +607,23 @@ describe("NodePath", function() {
         n.IfStatement.assert(remainingNodePath.node);
         n.UnaryExpression.assert(negatedTestExpression.node);
         assert.strictEqual(remainingNodePath, modifiedIfStatementNodePath);
-        assert.strictEqual(negatedTestExpression.get("argument").node, testNodePath.node);
-        assert.strictEqual(modifiedIfStatementNodePath.get("consequent").node, alternateNodePath.node);
+        assert.strictEqual(negatedTestExpression.node.operator, "!");
+    });
+
+    it("should modify if statement node if consequent is pruned, alternate remains with no double negation", function() {
+        var programPath = new NodePath(parse("if(!condition){var t = 0;}else{var f = 2;}"));
+        var consequentNodePath = programPath.get("body", 0, "consequent");
+
+        n.BlockStatement.assert(consequentNodePath.node);
+
+        var remainingNodePath = consequentNodePath.prune();
+
+        var modifiedIfStatementNodePath = programPath.get("body", 0);
+        var testExpression = modifiedIfStatementNodePath.get("test");
+
+        n.IfStatement.assert(remainingNodePath.node);
+        n.Identifier.assert(testExpression.node);
+        assert.strictEqual(remainingNodePath, modifiedIfStatementNodePath);
     });
 });
 


### PR DESCRIPTION
... after a prune.

If an IfStatement has it's consequent pruned and there is no alternate leave the test as
a ExpressionStatement. If the alternate still exists negate the test and move the alternate
to the consequent position.
