### PR TITLE
Add support for Acorn ImportBatchSpecifier and ParenthesizedExpression

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -190,6 +190,12 @@ def("Expression").bases("Node", "Pattern");
 
 def("ThisExpression").bases("Expression").build();
 
+// Acorn non-standard node
+def("ParenthesizedExpression")
+  .bases("Expression")
+  .build("expression")
+  .field("expression", def("Expression"));
+
 def("ArrayExpression")
     .bases("Expression")
     .build("elements")

--- a/def/es6.js
+++ b/def/es6.js
@@ -160,6 +160,12 @@ def("ImportSpecifier")
     .bases("NamedSpecifier")
     .build("id", "name");
 
+// Acorn: import <* as name> from ...;
+def("ImportBatchSpecifier")
+  .bases("Specifier")
+  .build("name")
+  .field("name", def("Identifier"));
+
 // import <* as id> from ...;
 def("ImportNamespaceSpecifier")
     .bases("Specifier")


### PR DESCRIPTION
This adds support for Acorn's non-standard `ParenthesizedExpression` node and `ImportBatchSpecifier` node which is `ImportNamespaceSpecifier` with a `name` instead of an `id`.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benjamn/ast-types/pull/74%23discussion_r20093615%22%2C%20%22https%3A//github.com/benjamn/ast-types/pull/74%23discussion_r20093811%22%2C%20%22https%3A//github.com/benjamn/ast-types/pull/74%23discussion_r20111133%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%208d892e9989c80d740f663758eb88c040d87d336e%20def/es6.js%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benjamn/ast-types/pull/74%23discussion_r20093811%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22using%20%60name%60%20instead%20of%20%60id%60%20here%20means%20tools%20like%20es6-module-transpiler%20will%20have%20trouble%20dealing%20with%20the%20AST.%20semantically%2C%20the%20%60id%60%20defines%20the%20identifier%20to%20be%20defined%20locally%2C%20while%20%60name%60%20defines%20the%20binding%20name%20from%20the%20module%20identifier.%20you%20can%20see%20how%20namespace%20and%20default%20specifiers%20will%20only%20use%20%60id%60.%22%2C%20%22created_at%22%3A%20%222014-11-10T16%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/38969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/caridy%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20def/es6.js%3AL160-172%22%7D%2C%20%22Pull%208d892e9989c80d740f663758eb88c040d87d336e%20def/es6.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benjamn/ast-types/pull/74%23discussion_r20093615%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22semantically%2C%20%60import%20%2A%20as%20name%20from%20...%60%20is%20not%20a%20batch%20operation%2C%20it%20is%20not%20doing%20any%20repetitive%20operation%2C%20instead%20it%20is%20declaring%20a%20new%20identifier%20that%20points%20to%20the%20live%20bindings%20of%20a%20module%2C%20this%20is%20completely%20different%20from%20%60export%20%2A%20from%20...%60%20in%20which%20case%20you%20will%20iterate%20over%20each%20binding%20%28based%20on%20the%20spec%27d%20algorithm%29%2C%20apply%20a%20logic%20to%20see%20if%20it%20should%20be%20defined%20as%20a%20named%20export%20identifier.%20the%20fact%20they%20use%20the%20same%20character%20%60%2A%60%20does%20not%20means%20they%20are%20the%20same%20thing.%22%2C%20%22created_at%22%3A%20%222014-11-10T16%3A42%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/38969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/caridy%22%7D%7D%2C%20%7B%22body%22%3A%20%22See%20marijnh/acorn%23157%22%2C%20%22created_at%22%3A%20%222014-11-10T20%3A43%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/853712%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sebmck%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20def/es6.js%3AL160-172%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8d892e9989c80d740f663758eb88c040d87d336e def/es6.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benjamn/ast-types/pull/74#discussion_r20093615'>File: def/es6.js:L160-172</a></b>
- <a href='https://github.com/caridy'><img border=0 src='https://avatars.githubusercontent.com/u/38969?v=3' height=16 width=16'></a> semantically, `import * as name from ...` is not a batch operation, it is not doing any repetitive operation, instead it is declaring a new identifier that points to the live bindings of a module, this is completely different from `export * from ...` in which case you will iterate over each binding (based on the spec'd algorithm), apply a logic to see if it should be defined as a named export identifier. the fact they use the same character `*` does not means they are the same thing.
- <a href='https://github.com/sebmck'><img border=0 src='https://avatars.githubusercontent.com/u/853712?v=3' height=16 width=16'></a> See marijnh/acorn#157
- [ ] <a href='#crh-comment-Pull 8d892e9989c80d740f663758eb88c040d87d336e def/es6.js 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benjamn/ast-types/pull/74#discussion_r20093811'>File: def/es6.js:L160-172</a></b>
- <a href='https://github.com/caridy'><img border=0 src='https://avatars.githubusercontent.com/u/38969?v=3' height=16 width=16'></a> using `name` instead of `id` here means tools like es6-module-transpiler will have trouble dealing with the AST. semantically, the `id` defines the identifier to be defined locally, while `name` defines the binding name from the module identifier. you can see how namespace and default specifiers will only use `id`.

<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/74?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/74?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benjamn/ast-types/pull/74'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
