### PR TITLE
Update to match esprima-fb & the Flow parser

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -32,7 +32,8 @@ def("Position")
 def("Program")
     .bases("Node")
     .build("body")
-    .field("body", [def("Statement")]);
+    .field("body", [def("Statement")])
+    .field("comments", or([or(def("Block"), def("Line"))], null), defaults["null"]);
 
 def("Function")
     .bases("Node")
@@ -344,3 +345,21 @@ def("Literal")
         isNumber,
         isRegExp
     ));
+
+// Block comment. Not a Node.
+def("Block")
+    .build("loc", "value")
+    .field("loc", or(
+        def("SourceLocation"),
+        null
+    ), defaults["null"], true)
+    .field("value", isString);
+
+// Single line comment. Not a Node.
+def("Line")
+  .build("loc", "value")
+  .field("loc", or(
+      def("SourceLocation"),
+      null
+  ), defaults["null"], true)
+  .field("value", isString);

--- a/def/es6.js
+++ b/def/es6.js
@@ -67,16 +67,22 @@ def("ModuleSpecifier")
 
 def("Property")
     // Esprima extensions not mentioned in the Mozilla Parser API:
+    .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
     .field("method", isBoolean, defaults["false"])
     .field("shorthand", isBoolean, defaults["false"])
+    .field("computed", isBoolean, defaults["false"]);
+
+def("PropertyPattern")
+    .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
     .field("computed", isBoolean, defaults["false"]);
 
 def("MethodDefinition")
     .bases("Declaration")
     .build("kind", "key", "value")
     .field("kind", or("init", "get", "set", ""))
-    .field("key", or(def("Literal"), def("Identifier")))
-    .field("value", def("Function"));
+    .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
+    .field("value", def("Function"))
+    .field("computed", isBoolean, defaults["false"]);
 
 def("SpreadElement")
     .bases("Node")
@@ -106,8 +112,9 @@ var ClassBodyElement = or(
 
 def("ClassProperty")
   .bases("Declaration")
-  .build("id")
-  .field("id", def("Identifier"));
+  .build("key")
+  .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
+  .field("computed", isBoolean, defaults["false"]);
 
 def("ClassPropertyDefinition") // static property
     .bases("Declaration")
@@ -132,6 +139,13 @@ def("ClassExpression")
     .build("id", "body", "superClass")
     .field("id", or(def("Identifier"), null), defaults["null"])
     .field("body", def("ClassBody"))
+    .field("superClass", or(def("Expression"), null), defaults["null"])
+    .field("implements", [def("ClassImplements")], defaults.emptyArray);
+
+def("ClassImplements")
+    .bases("Node")
+    .build("id")
+    .field("id", def("Identifier"))
     .field("superClass", or(def("Expression"), null), defaults["null"]);
 
 // Specifier and NamedSpecifier are abstract non-standard types that I


### PR DESCRIPTION
This updates ast-types to match the AST produced by the Flow Parser and [esprima-fb](https://github.com/facebook/esprima)

This supersedes #53.
