### PR TITLE
Introduce reportChanged API to keep state about whether a visitor changed the AST

### DIFF
--- a/lib/path-visitor.js
+++ b/lib/path-visitor.js
@@ -12,6 +12,7 @@ function PathVisitor() {
     assert.ok(this instanceof PathVisitor);
     this._reusableContextStack = [];
     this._methodNameTable = computeMethodNameTable(this);
+    this._changeReported = false;
     this.Context = makeContextConstructor(this);
 }
 
@@ -160,6 +161,14 @@ PVp.releaseContext = function(context) {
     context.currentPath = null;
 };
 
+PVp.reportChanged = function() {
+    this._changeReported = true;
+};
+
+PVp.wasChangeReported = function() {
+    return this._changeReported;
+};
+
 function makeContextConstructor(visitor) {
     function Context(path) {
         assert.ok(this instanceof Context);
@@ -249,6 +258,10 @@ function traverse(path, newVisitor) {
     visitChildren(path, PathVisitor.fromMethodsObject(
         newVisitor || this.visitor
     ));
+};
+
+sharedContextProtoMethods.reportChanged = function reportChanged() {
+    this.visitor.reportChanged();
 };
 
 module.exports = PathVisitor;


### PR DESCRIPTION
- reportChanged is both methods on the context and the visitor.
- the user calls the context method and the context method calls the visitor method.
- this is optional so the API names tries to reflect this: e.g. `wasChangeReported()` instead of `isChanged()`
