### PR TITLE
Add definition for ArrayTypeAnnotation

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -150,6 +150,11 @@ def("FunctionTypeParam")
   .field("name", def("Identifier"))
   .field("typeAnnotation", def("Type"))
   .field("optional", isBoolean);
+  
+def("ArrayTypeAnnotation")
+  .bases("Type")
+  .build("elementType")
+  .field("elementType", def("Type"));
 
 def("ObjectTypeAnnotation")
   .bases("Type")


### PR DESCRIPTION
I neglected to add a definition for ArrayTypeAnnotation, which is the type of the `number[]` syntax, like

  function foo(x: number[]) {}