### PR TITLE
definition for ArrowFunctionExpression builder is missing default value for field 'generator'

### DIFF
--- a/def/es6.js
+++ b/def/es6.js
@@ -31,7 +31,7 @@ def("ArrowFunctionExpression")
     .field("id", null, defaults["null"])
     // The current spec forbids arrow generators, so I have taken the
     // liberty of enforcing that. TODO Report this.
-    .field("generator", false);
+    .field("generator", false, defaults["false"]);
 
 def("YieldExpression")
     .bases("Expression")


### PR DESCRIPTION
Without this change, you get the following error when trying to create an ArrowFunctionExpression:
`AssertionError: no value or default function given for field "generator" of ArrowFunctionExpression("params": [Pattern], "body": BlockStatement | Expression, "expression": boolean)`