### PR TITLE
StringLiteralTypeAnnotation should be based on Literal

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -119,6 +119,7 @@ def("StringTypeAnnotation")
 
 def("StringLiteralTypeAnnotation")
   .bases("Type")
+  .bases("Literal")
   .build("value", "raw")
   .field("value", isString)
   .field("raw", isString);
@@ -150,7 +151,7 @@ def("FunctionTypeParam")
   .field("name", def("Identifier"))
   .field("typeAnnotation", def("Type"))
   .field("optional", isBoolean);
-  
+
 def("ArrayTypeAnnotation")
   .bases("Type")
   .build("elementType")
@@ -164,7 +165,7 @@ def("ObjectTypeAnnotation")
   .field("callProperties", [def("ObjectTypeCallProperty")], defaults.emptyArray);
 
 def("ObjectTypeProperty")
-  .bases("Node")
+  .bases("Literal")
   .build("key", "value", "optional")
   .field("key", or(def("Literal"), def("Identifier")))
   .field("value", def("Type"))
@@ -261,7 +262,7 @@ def("TypeAlias")
   .field("id", def("Identifier"))
   .field("typeParameters", or(def("TypeParameterDeclaration"), null))
   .field("right", def("Type"));
-  
+
 def("TypeCastExpression")
   .bases("Expression")
   .build("expression", "typeAnnotation")


### PR DESCRIPTION
I'm adding type annotation printing (wohoo) to recast and while I don't really know what StringLiteralTypeAnnotation does in flow, I think the ast-type for it should be based on Literal as well, just so that `nodeStr` in recast's printer module can be called on it.

cc @gabelevi 