### PR TITLE
Add ExpressionStatement wrappers for Expression builders

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -570,6 +570,13 @@ function getBuilderName(typeName) {
         }
     });
 }
+exports.getBuilderName = getBuilderName;
+
+function getStatementBuilderName(typeName) {
+    typeName = getBuilderName(typeName);
+    return typeName.replace(/(Expression)?$/, "Statement");
+}
+exports.getStatementBuilderName = getStatementBuilderName;
 
 // The reason fields are specified using .field(...) instead of an object
 // literal syntax is somewhat subtle: the object literal syntax would
@@ -678,8 +685,31 @@ Dp.finalize = function() {
 
         // A linearization of the inheritance hierarchy.
         populateSupertypeList(this.typeName, this.supertypeList);
+
+        if (this.buildable && this.supertypeList.lastIndexOf("Expression") >= 0) {
+            wrapExpressionBuilderWithStatement(this.typeName);
+        }
     }
 };
+
+// Adds an additional builder for Expression subtypes
+// that wraps the built Expression in an ExpressionStatements.
+function wrapExpressionBuilderWithStatement(typeName) {
+    var wrapperName = getStatementBuilderName(typeName);
+
+    // skip if the builder already exists
+    if (builders[wrapperName]) return;
+
+    // the builder function to wrap with builders.ExpressionStatement
+    var wrapped = builders[getBuilderName(typeName)];
+
+    // skip if there is nothing to wrap
+    if (!wrapped) return;
+
+    builders[wrapperName] = function() {
+        return builders.expressionStatement(wrapped.apply(builders, arguments));
+    };
+}
 
 function populateSupertypeList(typeName, list) {
     list.length = 0;

--- a/test/run.js
+++ b/test/run.js
@@ -10,6 +10,7 @@ var parse = esprima.parse;
 var Path = require("../lib/path");
 var NodePath = require("../lib/node-path");
 var PathVisitor = require("../lib/path-visitor");
+var rawTypes = require("../lib/types");
 
 describe("basic type checking", function() {
     var fooId = b.identifier("foo");
@@ -183,16 +184,17 @@ describe("whole-program validation", function() {
 });
 
 describe("esprima Syntax types", function() {
-    it("should all be buildable", function() {
-        var def = types.Type.def;
-        var todo = {
-            ClassHeritage: true,
-            ComprehensionBlock: true,
-            ComprehensionExpression: true,
-            ExportSpecifierSet: true,
-            Glob: true
-        };
+    var def = types.Type.def;
 
+    var todo = {
+        ClassHeritage: true,
+        ComprehensionBlock: true,
+        ComprehensionExpression: true,
+        ExportSpecifierSet: true,
+        Glob: true
+    };
+
+    it("should all be buildable", function() {
         Object.keys(esprimaSyntax).forEach(function(name) {
             if (todo[name] === true) return;
             assert.ok(n.hasOwnProperty(name), name);
@@ -202,6 +204,19 @@ describe("esprima Syntax types", function() {
             if (name in esprimaSyntax)
                 assert.ok(def(name).buildable, name);
         });
+    });
+
+    it("builders for subtypes of Expression should have equivalent ExpressionStatement builders", function() {
+        Object.keys(n).forEach(function(name) {
+            if (name in esprimaSyntax && def("Expression").isSupertypeOf(def(name)) && def(name).buildable) {
+                var statementBuilderName = rawTypes.getStatementBuilderName(name);
+                assert.ok(b[statementBuilderName], name + ":" +statementBuilderName);
+            }
+        });
+
+        // sanity check
+        var expStmt = b.assignmentStatement("=", b.identifier("a"), b.identifier("b"));
+        assert.strictEqual(expStmt.type, "ExpressionStatement");
     });
 });
 


### PR DESCRIPTION
If type is a subtype of Expression, add a second builder function
with an identical signature that automatically wraps the Expression
in an Expression statement, i.e.:
```javascript
   b.assignmentStatement(...)
   =>
   b.expressionStatement(b.assignmentExpression(...))
```

Closes #97 