### PR TITLE
[ES6 Modules] ModuleSpecifier -> Literal

### DIFF
--- a/def/es6.js
+++ b/def/es6.js
@@ -62,11 +62,6 @@ def("ComprehensionBlock")
     .field("right", def("Expression"))
     .field("each", isBoolean);
 
-def("ModuleSpecifier")
-    .bases("Literal")
-    .build("value")
-    .field("value", isString);
-
 def("Property")
     // Esprima extensions not mentioned in the Mozilla Parser API:
     .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
@@ -210,7 +205,7 @@ def("ExportDeclaration")
         def("ExportSpecifier"),
         def("ExportBatchSpecifier")
     )], defaults.emptyArray)
-    .field("source", or(def("ModuleSpecifier"), null), defaults["null"]);
+    .field("source", or(def("Literal"), null), defaults["null"]);
 
 def("ImportDeclaration")
     .bases("Declaration")
@@ -220,7 +215,7 @@ def("ImportDeclaration")
         def("ImportNamespaceSpecifier"),
         def("ImportDefaultSpecifier")
     )], defaults.emptyArray)
-    .field("source", def("ModuleSpecifier"));
+    .field("source", def("Literal"));
 
 def("TaggedTemplateExpression")
     .bases("Expression")

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "esprima": "~1.2.2",
-    "esprima-fb": "~7001.1.0-dev-harmony-fb",
+    "esprima-fb": "~14001.1.0-dev-harmony-fb",
     "mocha": "~1.20.1"
   },
   "engines": {

--- a/test/run.js
+++ b/test/run.js
@@ -1033,11 +1033,14 @@ describe("scope methods", function () {
     });
 
     it("getBindings should work for import statements", function() {
-        var ast = require("esprima-fb").parse([
+        var ast = require("esprima-fb").parse(
+          [
             "import {x, y as z} from 'xy';",
             "import xyDefault from 'xy';",
             "import * as xyNamespace from 'xy';"
-        ].join("\n"));
+          ].join("\n"),
+          {sourceType: "module"}
+        );
 
         var names;
 


### PR DESCRIPTION
Looks like esprima updated to match acorn and SpiderMonkey: https://github.com/jquery/esprima/pull/1086
And it looks like estree went this way too: https://github.com/estree/estree/pull/35

I'm updating the Flow parser to match.