### PR TITLE
fix: type field type

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -478,7 +478,7 @@ Dp.build = function(/* param1, param2, ... */) {
     // Every buildable type will have its "type" field filled in
     // automatically. This includes types that are not subtypes of Node,
     // like SourceLocation, but that seems harmless (TODO?).
-    self.field("type", self.typeName, function() { return self.typeName });
+    self.field("type", isString, function() { return self.typeName });
 
     // Override Dp.buildable for this Def instance.
     Object.defineProperty(self, "buildable", { value: true });


### PR DESCRIPTION
This is causing me issues when introspecting the defined types for typescript definition file generation. Buildable types have their `type` field automatically set, but I believe it's being done incorrectly. For example `Identifier` has it's `type` field set to type `"Identifier"`, with a default value of `"Identifier"`. It should be set to type `"string"` with a default value of `"Identifier"`.