### PR TITLE
Update ClassProperty type.

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -262,9 +262,11 @@ def("Function")
          defaults["null"]);
 
 def("ClassProperty")
-  .build("key", "typeAnnotation")
-  .field("typeAnnotation", def("TypeAnnotation"))
-  .field("static", Boolean, false);
+  .build("key", "value", "typeAnnotation", "static")
+  .field("key", def("Identifier"))
+  .field("value", or(def("Expression"), null))
+  .field("typeAnnotation", or(def("TypeAnnotation"), null))
+  .field("static", Boolean, defaults["false"]);
 
 def("ClassImplements")
   .field("typeParameters",


### PR DESCRIPTION
This updates the ClassProperty type to allow for property initializers (recast diff upcoming).

I changed how the type is build up and this is a breaking API change. I don't think anyone is relying on this so it should be fine, right? :)