### PR TITLE
Fix ClassProperty fb-harmony definition

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -262,8 +262,7 @@ def("Function")
          defaults["null"]);
 
 def("ClassProperty")
-  .build("key", "value", "typeAnnotation", "static")
-  .field("key", def("Identifier"))
+  .build("key", "value", "typeAnnotation")
   .field("value", or(def("Expression"), null))
   .field("typeAnnotation", or(def("TypeAnnotation"), null))
   .field("static", Boolean, defaults["false"]);


### PR DESCRIPTION
The key can also be a literal or an expression. Also, I don't see a good reason to have static in the build (not a big deal, can revert that part if you disagree)