### PR TITLE
Fix comments. Fixes recast/203

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -358,14 +358,10 @@ def("Comment")
     .field("leading", Boolean, defaults["true"])
     .field("trailing", Boolean, defaults["false"]);
 
-// Block comment. The .type really should be BlockComment rather than
-// Block, but that's what we're stuck with for now.
-def("Block")
+def("CommentBlock")
     .bases("Comment")
     .build("value", /*optional:*/ "leading", "trailing");
 
-// Single line comment. The .type really should be LineComment rather than
-// Line, but that's what we're stuck with for now.
-def("Line")
+def("CommentLine")
     .bases("Comment")
     .build("value", /*optional:*/ "leading", "trailing");

--- a/def/esprima.js
+++ b/def/esprima.js
@@ -94,3 +94,9 @@ def("ImportDeclaration")
         def("ImportDefaultSpecifier")
     )], defaults.emptyArray)
     .field("source", def("Literal"));
+
+def("Block")
+  .bases("CommentBlock");
+
+def("Line")
+  .bases("CommentLine");


### PR DESCRIPTION
I originally mapped `CommentBlock` to `Block` etc. in babel.js but then Ben suggested to do the opposite thing.