### PR TITLE
expose parameter metadata for builder functions

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -723,6 +723,31 @@ Dp.finalize = function() {
         if (self.buildable && self.supertypeList.lastIndexOf("Expression") >= 0) {
             wrapExpressionBuilderWithStatement(self.typeName);
         }
+
+        if (self.buildable) {
+            var buildFn = builders[getBuilderName(self.typeName)];
+
+            self.buildParams.forEach(function(param, i) {
+                var paramDef = {};
+
+                Object.defineProperty(paramDef, "name", {
+                    enumerable: true,
+                    value: param
+                });
+
+                Object.defineProperty(paramDef, "type", {
+                    enumerable: true,
+                    value: self.allFields[param].type
+                });
+
+                Object.defineProperty(buildFn, "" + i, {
+                    enumerable: true,
+                    value: paramDef
+                });
+            });
+
+            Object.defineProperty(buildFn, "paramCount", {value: self.buildParams.length});
+        }
     }
 };
 

--- a/test/run.js
+++ b/test/run.js
@@ -2122,3 +2122,21 @@ describe("RegExpLiteral nodes", function() {
         assert.strictEqual(n.Literal.check(regExpLiteral, true), false);
     });
 });
+
+describe("Custom Types", function() {
+    types.Type.def("MyCustomType")
+      .bases("Node")
+      .build("a", "b")
+      .field("a", String)
+      .field("b", Number);
+
+    types.finalize();
+    
+    it("builder function", function() {
+        assert.strictEqual(b.myCustomType.paramCount, 2);
+        assert.strictEqual(b.myCustomType[0].name, "a");
+        assert.strictEqual(b.myCustomType[0].type, builtin.string);
+        assert.strictEqual(b.myCustomType[1].name, "b");
+        assert.strictEqual(b.myCustomType[1].type, builtin.number);
+    });
+});


### PR DESCRIPTION
Closes #84 

```js
var types = require('ast-types');
var assert = require('assert');
var b = types.builders;
var n = types.namedTypes;

assert.strictEqual(b.whileStatement.paramCount, 2);

assert.deepEqual(b.whileStatement[0], {
  name: 'test',
  body: n.Expression
});

assert.deepEqual(b.whileStatement[1], {
  name: 'body',
  body: n.Statement
});
```
