### PR TITLE
Fix ImportDefaultSpecifier AST conflict

### DIFF
--- a/def/esprima.js
+++ b/def/esprima.js
@@ -51,15 +51,13 @@ def("ImportSpecifier")
 
 // import <* as id> from ...;
 def("ImportNamespaceSpecifier")
-    .bases("Specifier")
-    .build("id")
-    .field("id", def("Identifier"));
+    .bases("ModuleSpecifier")
+    .build("id");
 
 // import <id> from ...;
 def("ImportDefaultSpecifier")
-    .bases("Specifier")
-    .build("id")
-    .field("id", def("Identifier"));
+    .bases("ModuleSpecifier")
+    .build("id");
 
 def("ExportDeclaration")
     .bases("Declaration")

--- a/test/run.js
+++ b/test/run.js
@@ -12,6 +12,7 @@ var builtin = types.builtInTypes
 var isRegExp = builtin.RegExp;
 var isString = builtin.string;
 var rawTypes = require("../lib/types");
+
 var hasOwn = Object.prototype.hasOwnProperty;
 
 describe("basic type checking", function() {
@@ -34,6 +35,16 @@ describe("basic type checking", function() {
         assert.ok(n.Expression.check(ifFoo.test));
         assert.ok(n.Identifier.check(ifFoo.test));
         assert.ok(!n.Statement.check(ifFoo.test));
+        assert.ok(n.ImportDeclaration.check(
+          b.importDeclaration(
+            [b.importDefaultSpecifier(b.identifier("foo"))], b.literal("bar"))
+          )
+        );
+        assert.ok(n.ImportDeclaration.check(
+          b.importDeclaration(
+            [b.importNamespaceSpecifier(b.identifier("foo"))], b.literal("bar"))
+          )
+        );
     });
 });
 


### PR DESCRIPTION
This fix the problem that I commented in https://github.com/benjamn/recast/issues/206#issuecomment-129266283. I just used the same idea from [babel's ImportDefaultSpecifier](https://github.com/benjamn/ast-types/blob/master/def/babel.js#L58-L60): uses `ModuleSpecifier` as base node and build the needed field, in esprima case the `id` field.

//cc @benjamn 