### PR TITLE
Fixes #6

### DIFF
--- a/lib/equiv.js
+++ b/lib/equiv.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var types = require("../main");
 var getFieldNames = types.getFieldNames;
 var getFieldValue = types.getFieldValue;
@@ -22,10 +21,11 @@ astNodesAreEquivalent.assert = function(a, b) {
     var problemPath = [];
     if (!astNodesAreEquivalent(a, b, problemPath)) {
         if (problemPath.length === 0) {
-            assert.strictEqual(a, b);
+            if (a !== b) {
+                throw new Error("Nodes must be equal");
+            }
         } else {
-            assert.ok(
-                false,
+            throw new Error(
                 "Nodes differ in the following path: " +
                     problemPath.map(subscriptForProperty).join("")
             );
@@ -94,7 +94,10 @@ function arraysAreEquivalent(a, b, problemPath) {
         }
 
         if (problemPath) {
-            assert.strictEqual(problemPath.pop(), i);
+            var problemPathTail = problemPath.pop();
+            if (problemPathTail !== i) {
+                throw new Error("" + problemPathTail);
+            }
         }
     }
 
@@ -136,7 +139,10 @@ function objectsAreEquivalent(a, b, problemPath) {
             }
 
             if (problemPath) {
-                assert.strictEqual(problemPath.pop(), name);
+                var problemPathTail = problemPath.pop();
+                if (problemPathTail !== name) {
+                    throw new Error("" + problemPathTail);
+                }
             }
         }
 

--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var types = require("./types");
 var n = types.namedTypes;
 var b = types.builders;
@@ -8,12 +7,20 @@ var Path = require("./path");
 var Scope = require("./scope");
 
 function NodePath(value, parentPath, name) {
-    assert.ok(this instanceof NodePath);
+    if (!(this instanceof NodePath)) {
+        throw new Error("NodePath constructor cannot be invoked without 'new'");
+    }
     Path.call(this, value, parentPath, name);
 }
 
-require("util").inherits(NodePath, Path);
-var NPp = NodePath.prototype;
+var NPp = NodePath.prototype = Object.create(Path.prototype, {
+    constructor: {
+        value: NodePath,
+        enumerable: false,
+        writable: true,
+        configurable: true
+    }
+});
 
 Object.defineProperties(NPp, {
     node: {
@@ -192,7 +199,9 @@ NPp.needsParens = function(assumeExpressionContext) {
             }
 
             if (pp === np && this.name === "right") {
-                assert.strictEqual(parent.right, node);
+                if (parent.right !== node) {
+                    throw new Error("Nodes must be equal");
+                }
                 return true;
             }
 
@@ -350,51 +359,67 @@ function firstInStatement(path) {
         if (n.BlockStatement.check(parent) &&
             path.parent.name === "body" &&
             path.name === 0) {
-            assert.strictEqual(parent.body[0], node);
+            if (parent.body[0] !== node) {
+                throw new Error("Nodes must be equal");
+            }
             return true;
         }
 
         if (n.ExpressionStatement.check(parent) &&
             path.name === "expression") {
-            assert.strictEqual(parent.expression, node);
+            if (parent.expression !== node) {
+                throw new Error("Nodes must be equal");
+            }
             return true;
         }
 
         if (n.SequenceExpression.check(parent) &&
             path.parent.name === "expressions" &&
             path.name === 0) {
-            assert.strictEqual(parent.expressions[0], node);
+            if (parent.expressions[0] !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 
         if (n.CallExpression.check(parent) &&
             path.name === "callee") {
-            assert.strictEqual(parent.callee, node);
+            if (parent.callee !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 
         if (n.MemberExpression.check(parent) &&
             path.name === "object") {
-            assert.strictEqual(parent.object, node);
+            if (parent.object !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 
         if (n.ConditionalExpression.check(parent) &&
             path.name === "test") {
-            assert.strictEqual(parent.test, node);
+            if (parent.test !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 
         if (isBinary(parent) &&
             path.name === "left") {
-            assert.strictEqual(parent.left, node);
+            if (parent.left !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 
         if (n.UnaryExpression.check(parent) &&
             !parent.prefix &&
             path.name === "argument") {
-            assert.strictEqual(parent.argument, node);
+            if (parent.argument !== node) {
+                throw new Error("Nodes must be equal");
+            }
             continue;
         }
 

--- a/lib/path-visitor.js
+++ b/lib/path-visitor.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var types = require("./types");
 var NodePath = require("./node-path");
 var Printable = types.namedTypes.Printable;
@@ -9,7 +8,11 @@ var hasOwn = Object.prototype.hasOwnProperty;
 var undefined;
 
 function PathVisitor() {
-    assert.ok(this instanceof PathVisitor);
+    if (!(this instanceof PathVisitor)) {
+        throw new Error(
+            "PathVisitor constructor cannot be invoked without 'new'"
+        );
+    }
 
     // Permanent state.
     this._reusableContextStack = [];
@@ -62,7 +65,11 @@ PathVisitor.fromMethodsObject = function fromMethodsObject(methods) {
     }
 
     function Visitor() {
-        assert.ok(this instanceof Visitor);
+        if (!(this instanceof Visitor)) {
+            throw new Error(
+                "Visitor constructor cannot be invoked without 'new'"
+            );
+        }
         PathVisitor.call(this);
     }
 
@@ -94,13 +101,13 @@ PathVisitor.visit = function visit(node, methods) {
 
 var PVp = PathVisitor.prototype;
 
-var recursiveVisitWarning = [
-    "Recursively calling visitor.visit(path) resets visitor state.",
-    "Try this.visit(path) or this.traverse(path) instead."
-].join(" ");
-
 PVp.visit = function() {
-    assert.ok(!this._visiting, recursiveVisitWarning);
+    if (this._visiting) {
+        throw new Error(
+            "Recursively calling visitor.visit(path) resets visitor state. " +
+                "Try this.visit(path) or this.traverse(path) instead."
+        );
+    }
 
     // Private state that needs to be reset before every traversal.
     this._visiting = true;
@@ -170,7 +177,10 @@ PVp.visitWithoutReset = function(path) {
         return this.visitor.visitWithoutReset(path);
     }
 
-    assert.ok(path instanceof NodePath);
+    if (!(path instanceof NodePath)) {
+        throw new Error("");
+    }
+
     var value = path.value;
 
     var methodName = value &&
@@ -194,8 +204,12 @@ PVp.visitWithoutReset = function(path) {
 };
 
 function visitChildren(path, visitor) {
-    assert.ok(path instanceof NodePath);
-    assert.ok(visitor instanceof PathVisitor);
+    if (!(path instanceof NodePath)) {
+        throw new Error("");
+    }
+    if (!(visitor instanceof PathVisitor)) {
+        throw new Error("");
+    }
 
     var value = path.value;
 
@@ -242,7 +256,9 @@ PVp.acquireContext = function(path) {
 };
 
 PVp.releaseContext = function(context) {
-    assert.ok(context instanceof this.Context);
+    if (!(context instanceof this.Context)) {
+        throw new Error("");
+    }
     this._reusableContextStack.push(context);
     context.currentPath = null;
 };
@@ -257,9 +273,15 @@ PVp.wasChangeReported = function() {
 
 function makeContextConstructor(visitor) {
     function Context(path) {
-        assert.ok(this instanceof Context);
-        assert.ok(this instanceof PathVisitor);
-        assert.ok(path instanceof NodePath);
+        if (!(this instanceof Context)) {
+            throw new Error("");
+        }
+        if (!(this instanceof PathVisitor)) {
+            throw new Error("");
+        }
+        if (!(path instanceof NodePath)) {
+            throw new Error("");
+        }
 
         Object.defineProperty(this, "visitor", {
             value: visitor,
@@ -274,7 +296,9 @@ function makeContextConstructor(visitor) {
         Object.seal(this);
     }
 
-    assert.ok(visitor instanceof PathVisitor);
+    if (!(visitor instanceof PathVisitor)) {
+        throw new Error("");
+    }
 
     // Note that the visitor object is the prototype of Context.prototype,
     // so all visitor methods are inherited by context objects.
@@ -293,8 +317,12 @@ var sharedContextProtoMethods = Object.create(null);
 
 sharedContextProtoMethods.reset =
 function reset(path) {
-    assert.ok(this instanceof this.Context);
-    assert.ok(path instanceof NodePath);
+    if (!(this instanceof this.Context)) {
+        throw new Error("");
+    }
+    if (!(path instanceof NodePath)) {
+        throw new Error("");
+    }
 
     this.currentPath = path;
     this.needToCallTraverse = true;
@@ -304,8 +332,12 @@ function reset(path) {
 
 sharedContextProtoMethods.invokeVisitorMethod =
 function invokeVisitorMethod(methodName) {
-    assert.ok(this instanceof this.Context);
-    assert.ok(this.currentPath instanceof NodePath);
+    if (!(this instanceof this.Context)) {
+        throw new Error("");
+    }
+    if (!(this.currentPath instanceof NodePath)) {
+        throw new Error("");
+    }
 
     var result = this.visitor[methodName].call(this, this.currentPath);
 
@@ -327,10 +359,11 @@ function invokeVisitorMethod(methodName) {
         }
     }
 
-    assert.strictEqual(
-        this.needToCallTraverse, false,
-        "Must either call this.traverse or return false in " + methodName
-    );
+    if (this.needToCallTraverse !== false) {
+        throw new Error(
+            "Must either call this.traverse or return false in " + methodName
+        );
+    }
 
     var path = this.currentPath;
     return path && path.value;
@@ -338,9 +371,15 @@ function invokeVisitorMethod(methodName) {
 
 sharedContextProtoMethods.traverse =
 function traverse(path, newVisitor) {
-    assert.ok(this instanceof this.Context);
-    assert.ok(path instanceof NodePath);
-    assert.ok(this.currentPath instanceof NodePath);
+    if (!(this instanceof this.Context)) {
+        throw new Error("");
+    }
+    if (!(path instanceof NodePath)) {
+        throw new Error("");
+    }
+    if (!(this.currentPath instanceof NodePath)) {
+        throw new Error("");
+    }
 
     this.needToCallTraverse = false;
 
@@ -351,9 +390,15 @@ function traverse(path, newVisitor) {
 
 sharedContextProtoMethods.visit =
 function visit(path, newVisitor) {
-    assert.ok(this instanceof this.Context);
-    assert.ok(path instanceof NodePath);
-    assert.ok(this.currentPath instanceof NodePath);
+    if (!(this instanceof this.Context)) {
+        throw new Error("");
+    }
+    if (!(path instanceof NodePath)) {
+        throw new Error("");
+    }
+    if (!(this.currentPath instanceof NodePath)) {
+        throw new Error("");
+    }
 
     this.needToCallTraverse = false;
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var Op = Object.prototype;
 var hasOwn = Op.hasOwnProperty;
 var types = require("./types");
@@ -9,10 +8,14 @@ var slice = Ap.slice;
 var map = Ap.map;
 
 function Path(value, parentPath, name) {
-    assert.ok(this instanceof Path);
+    if (!(this instanceof Path)) {
+        throw new Error("Path constructor cannot be invoked without 'new'");
+    }
 
     if (parentPath) {
-        assert.ok(parentPath instanceof Path);
+        if (!(parentPath instanceof Path)) {
+            throw new Error("");
+        }
     } else {
         parentPath = null;
         name = null;
@@ -154,7 +157,9 @@ function getMoves(path, offset, start, end) {
     for (var i = start; i < end; ++i) {
         if (hasOwn.call(path.value, i)) {
             var childPath = path.get(i);
-            assert.strictEqual(childPath.name, i);
+            if (childPath.name !== i) {
+                throw new Error("");
+            }
             var newIndex = i + offset;
             childPath.name = newIndex;
             moves[newIndex] = childPath;
@@ -167,7 +172,9 @@ function getMoves(path, offset, start, end) {
     return function() {
         for (var newIndex in moves) {
             var childPath = moves[newIndex];
-            assert.strictEqual(childPath.name, +newIndex);
+            if (childPath.name !== +newIndex) {
+                throw new Error("");
+            }
             cache[newIndex] = childPath;
             path.value[newIndex] = childPath.value;
         }
@@ -241,7 +248,9 @@ Pp.insertAfter = function insertAfter(node) {
 };
 
 function repairRelationshipWithParent(path) {
-    assert.ok(path instanceof Path);
+    if (!(path instanceof Path)) {
+        throw new Error("");
+    }
 
     var pp = path.parentPath;
     if (!pp) {
@@ -270,8 +279,12 @@ function repairRelationshipWithParent(path) {
         parentCache[path.name] = path;
     }
 
-    assert.strictEqual(parentValue[path.name], path.value);
-    assert.strictEqual(path.parentPath.get(path.name), path);
+    if (parentValue[path.name] !== path.value) {
+        throw new Error("");
+    }
+    if (path.parentPath.get(path.name) !== path) {
+        throw new Error("");
+    }
 
     return path;
 }
@@ -295,11 +308,12 @@ Pp.replace = function replace(replacement) {
 
         var splicedOut = parentValue.splice.apply(parentValue, spliceArgs);
 
-        assert.strictEqual(splicedOut[0], this.value);
-        assert.strictEqual(
-            parentValue.length,
-            originalLength - 1 + count
-        );
+        if (splicedOut[0] !== this.value) {
+            throw new Error("");
+        }
+        if (parentValue.length !== (originalLength - 1 + count)) {
+            throw new Error("");
+        }
 
         move();
 
@@ -309,7 +323,9 @@ Pp.replace = function replace(replacement) {
             this.__childCache = null;
 
         } else {
-            assert.strictEqual(parentValue[this.name], replacement);
+            if (parentValue[this.name] !== replacement) {
+                throw new Error("");
+            }
 
             if (this.value !== replacement) {
                 this.value = replacement;
@@ -320,7 +336,9 @@ Pp.replace = function replace(replacement) {
                 results.push(this.parentPath.get(this.name + i));
             }
 
-            assert.strictEqual(results[0], this);
+            if (results[0] !== this) {
+                throw new Error("");
+            }
         }
 
     } else if (count === 1) {
@@ -339,7 +357,7 @@ Pp.replace = function replace(replacement) {
         // it no longer has a value defined.
 
     } else {
-        assert.ok(false, "Could not replace path");
+        throw new Error("Could not replace path");
     }
 
     return results;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var types = require("./types");
 var Type = types.Type;
 var namedTypes = types.namedTypes;
@@ -9,14 +8,20 @@ var hasOwn = Object.prototype.hasOwnProperty;
 var b = types.builders;
 
 function Scope(path, parentScope) {
-    assert.ok(this instanceof Scope);
-    assert.ok(path instanceof require("./node-path"));
+    if (!(this instanceof Scope)) {
+        throw new Error("Scope constructor cannot be invoked without 'new'");
+    }
+    if (!(path instanceof require("./node-path"))) {
+        throw new Error("");
+    }
     ScopeType.assert(path.value);
 
     var depth;
 
     if (parentScope) {
-        assert.ok(parentScope instanceof Scope);
+        if (!(parentScope instanceof Scope)) {
+            throw new Error("");
+        }
         depth = parentScope.depth + 1;
     } else {
         parentScope = null;
@@ -64,7 +69,9 @@ Sp.declares = function(name) {
 
 Sp.declareTemporary = function(prefix) {
     if (prefix) {
-        assert.ok(/^[a-z$_]/i.test(prefix), prefix);
+        if (!/^[a-z$_]/i.test(prefix)) {
+            throw new Error("");
+        }
     } else {
         prefix = "t$";
     }
@@ -177,7 +184,9 @@ function recursiveScanScope(path, bindings) {
     } else if (Node.check(node) && !Expression.check(node)) {
         types.eachField(node, function(name, child) {
             var childPath = path.get(name);
-            assert.strictEqual(childPath.value, child);
+            if (childPath.value !== child) {
+                throw new Error("");
+            }
             recursiveScanChild(childPath, bindings);
         });
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var Ap = Array.prototype;
 var slice = Ap.slice;
 var map = Ap.map;
@@ -14,18 +13,22 @@ var hasOwn = Op.hasOwnProperty;
 
 function Type(check, name) {
     var self = this;
-    assert.ok(self instanceof Type, self);
+    if (!(self instanceof Type)) {
+        throw new Error("Type constructor cannot be invoked without 'new'");
+    }
 
     // Unfortunately we can't elegantly reuse isFunction and isString,
     // here, because this code is executed while defining those types.
-    assert.strictEqual(objToStr.call(check), funObjStr,
-                       check + " is not a function");
+    if (objToStr.call(check) !== funObjStr) {
+        throw new Error(check + " is not a function");
+    }
 
     // The `name` parameter can be either a function or a string.
     var nameObjStr = objToStr.call(name);
-    assert.ok(nameObjStr === funObjStr ||
-              nameObjStr === strObjStr,
-              name + " is neither a function nor a string");
+    if (!(nameObjStr === funObjStr ||
+          nameObjStr === strObjStr)) {
+        throw new Error(name + " is neither a function nor a string");
+    }
 
     Object.defineProperties(self, {
         name: { value: name },
@@ -50,8 +53,7 @@ exports.Type = Type;
 Tp.assert = function(value, deep) {
     if (!this.check(value, deep)) {
         var str = shallowStringify(value);
-        assert.ok(false, str + " does not match type " + this);
-        return false;
+        throw new Error(str + " does not match type " + this);
     }
     return true;
 };
@@ -180,10 +182,12 @@ Type.or = function(/* type1, type2, ... */) {
 };
 
 Type.fromArray = function(arr) {
-    assert.ok(isArray.check(arr));
-    assert.strictEqual(
-        arr.length, 1,
-        "only one element type is permitted for typed arrays");
+    if (!isArray.check(arr)) {
+        throw new Error("");
+    }
+    if (arr.length !== 1) {
+        throw new Error("only one element type is permitted for typed arrays");
+    }
     return toType(arr[0]).arrayOf();
 };
 
@@ -215,7 +219,9 @@ Type.fromObject = function(obj) {
 function Field(name, type, defaultFn, hidden) {
     var self = this;
 
-    assert.ok(self instanceof Field);
+    if (!(self instanceof Field)) {
+        throw new Error("Field constructor cannot be invoked without 'new'");
+    }
     isString.assert(name);
 
     type = toType(type);
@@ -269,7 +275,9 @@ var defCache = Object.create(null);
 
 function Def(typeName) {
     var self = this;
-    assert.ok(self instanceof Def);
+    if (!(self instanceof Def)) {
+        throw new Error("Def constructor cannot be invoked without 'new'");
+    }
 
     Object.defineProperties(self, {
         typeName: { value: typeName },
@@ -309,20 +317,26 @@ var Dp = Def.prototype;
 
 Dp.isSupertypeOf = function(that) {
     if (that instanceof Def) {
-        assert.strictEqual(this.finalized, true);
-        assert.strictEqual(that.finalized, true);
+        if (this.finalized !== true ||
+            that.finalized !== true) {
+            throw new Error("");
+        }
         return hasOwn.call(that.allSupertypes, this.typeName);
     } else {
-        assert.ok(false, that + " is not a Def");
+        throw new Error(that + " is not a Def");
     }
 };
 
 // Note that the list returned by this function is a copy of the internal
 // supertypeList, *without* the typeName itself as the first element.
 exports.getSupertypeNames = function(typeName) {
-    assert.ok(hasOwn.call(defCache, typeName));
+    if (!hasOwn.call(defCache, typeName)) {
+        throw new Error("");
+    }
     var d = defCache[typeName];
-    assert.strictEqual(d.finalized, true);
+    if (d.finalized !== true) {
+        throw new Error("");
+    }
     return d.supertypeList.slice(1);
 };
 
@@ -337,7 +351,9 @@ exports.computeSupertypeLookupTable = function(candidates) {
     for (var i = 0; i < typeNameCount; ++i) {
         var typeName = typeNames[i];
         var d = defCache[typeName];
-        assert.strictEqual(d.finalized, true, typeName);
+        if (d.finalized !== true) {
+            throw new Error("" + typeName);
+        }
         for (var j = 0; j < d.supertypeList.length; ++j) {
             var superTypeName = d.supertypeList[j];
             if (hasOwn.call(candidates, superTypeName)) {
@@ -352,7 +368,9 @@ exports.computeSupertypeLookupTable = function(candidates) {
 
 Dp.checkAllFields = function(value, deep) {
     var allFields = this.allFields;
-    assert.strictEqual(this.finalized, true, this.typeName);
+    if (this.finalized !== true) {
+        throw new Error("" + this.typeName);
+    }
 
     function checkFieldByName(name) {
         var field = allFields[name];
@@ -366,9 +384,11 @@ Dp.checkAllFields = function(value, deep) {
 };
 
 Dp.check = function(value, deep) {
-    assert.strictEqual(
-        this.finalized, true,
-        "prematurely checking unfinalized type " + this.typeName);
+    if (this.finalized !== true) {
+        throw new Error(
+            "prematurely checking unfinalized type " + this.typeName
+        );
+    }
 
     // A Def type can only match an object value.
     if (!isObject.check(value))
@@ -420,7 +440,14 @@ Dp.bases = function() {
     var bases = this.baseNames;
 
     if (this.finalized) {
-        assert.deepEqual(args, bases);
+        if (args.length !== bases.length) {
+            throw new Error("");
+        }
+        for (var i = 0; i < args.length; i++) {
+            if (args[i] !== bases[i]) {
+                throw new Error("");
+            }
+        }
         return this;
     }
 
@@ -510,16 +537,21 @@ Dp.build = function(/* param1, param2, ... */) {
             var argc = args.length;
             var built = Object.create(nodePrototype);
 
-            assert.ok(
-                self.finalized,
-                "attempting to instantiate unfinalized type " + self.typeName);
+            if (!self.finalized) {
+                throw new Error(
+                    "attempting to instantiate unfinalized type " +
+                        self.typeName
+                );
+            }
 
             function add(param, i) {
                 if (hasOwn.call(built, param))
                     return;
 
                 var all = self.allFields;
-                assert.ok(hasOwn.call(all, param), param);
+                if (!hasOwn.call(all, param)) {
+                    throw new Error("" + param);
+                }
 
                 var field = all[param];
                 var type = field.type;
@@ -537,12 +569,11 @@ Dp.build = function(/* param1, param2, ... */) {
                             self.buildParams.map(function(name) {
                                 return all[name];
                             }).join(", ") + ")";
-                    assert.ok(false, message);
+                    throw new Error(message);
                 }
 
                 if (!type.check(value)) {
-                    assert.ok(
-                        false,
+                    throw new Error(
                         shallowStringify(value) +
                             " does not match field " + field +
                             " of type " + self.typeName
@@ -563,7 +594,9 @@ Dp.build = function(/* param1, param2, ... */) {
             });
 
             // Make sure that the "type" field was filled automatically.
-            assert.strictEqual(built.type, self.typeName);
+            if (built.type !== self.typeName) {
+                throw new Error("");
+            }
 
             return built;
         }
@@ -623,8 +656,7 @@ function getFieldNames(object) {
     }
 
     if ("type" in object) {
-        assert.ok(
-            false,
+        throw new Error(
             "did not recognize object of type " +
                 JSON.stringify(object.type)
         );
@@ -693,7 +725,7 @@ Dp.finalize = function() {
                     JSON.stringify(name) +
                     " for subtype " +
                     JSON.stringify(self.typeName);
-                assert.ok(false, message);
+                throw new Error(message);
             }
         });
 
@@ -754,7 +786,9 @@ function populateSupertypeList(typeName, list) {
     for (var pos = 0; pos < list.length; ++pos) {
         typeName = list[pos];
         var d = defCache[typeName];
-        assert.strictEqual(d.finalized, true);
+        if (d.finalized !== true) {
+            throw new Error("");
+        }
 
         // If we saw typeName earlier in the breadth-first traversal,
         // delete the last-seen occurrence.


### PR DESCRIPTION
Remove uses of the builtin `util` and `assert` modules. This results in much slimmer browserify builds.

| | before | after |
| ---: | ---: | ---: |
| browserify | 142,232 | 114,562 |
| browserify + uglify | 63,840 | 54,728 |

I went with inlining instead of using [inherits](https://www.npmjs.com/package/inherits) and [invariant](https://www.npmjs.com/package/invariant), since it seems that ast-types wants to stay dependency free.

@benjamn Please let me know if this is ok so I can take the time to write meaningful errors (or not - if empty errors are ok).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benjamn/ast-types/pull/128%23issuecomment-138786129%22%2C%20%22https%3A//github.com/benjamn/ast-types/pull/128%23issuecomment-138787817%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benjamn/ast-types/pull/128%23issuecomment-138786129%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Isn%27t%20almost%20any%20larger%20project%20that%20uses%20this%20going%20to%20be%20making%20use%20of%20%60assert%60%20and%20%60util%60%20themselves%3F%20%28or%20at%20least%20one%20of%20their%20dependencies%20will%29.%22%2C%20%22created_at%22%3A%20%222015-09-09T05%3A08%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4082216%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jamestalmage%22%7D%7D%2C%20%7B%22body%22%3A%20%22Babel%20doesn%27t%20use%20%60assert%60%20outside%20of%20tests%20%5Cu2013%20it%20does%20use%20%60util%60%20for%20%60inherits%60%20and%20%60inspect%60%2C%20which%20I%27ll%20be%20replacing%20next%22%2C%20%22created_at%22%3A%20%222015-09-09T05%3A19%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/830952%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zertosh%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benjamn/ast-types/pull/128#issuecomment-138786129'>General Comment</a></b>
- <a href='https://github.com/jamestalmage'><img border=0 src='https://avatars.githubusercontent.com/u/4082216?v=3' height=16 width=16'></a> Isn't almost any larger project that uses this going to be making use of `assert` and `util` themselves? (or at least one of their dependencies will).
- <a href='https://github.com/zertosh'><img border=0 src='https://avatars.githubusercontent.com/u/830952?v=3' height=16 width=16'></a> Babel doesn't use `assert` outside of tests – it does use `util` for `inherits` and `inspect`, which I'll be replacing next


<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/128?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benjamn/ast-types/pull/128?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benjamn/ast-types/pull/128'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>