### PR TITLE
TypeAlias is a Declaration, not just a Statement

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -289,7 +289,7 @@ def("InterfaceExtends")
   .field("typeParameters", or(def("TypeParameterInstantiation"), null));
 
 def("TypeAlias")
-  .bases("Statement")
+  .bases("Declaration")
   .build("id", "typeParameters", "right")
   .field("id", def("Identifier"))
   .field("typeParameters", or(def("TypeParameterDeclaration"), null))


### PR DESCRIPTION
You can export a type alias, but `ExportDeclaration`'s `declaration` field only allows `Declaration`, `Expression`, or `null`.

To test I ran ast-types against the output of Flow's parser for

```JavaScript
export type A = number
```