### PR TITLE
DeclareExportDeclaration

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -325,3 +325,23 @@ def("DeclareModule")
   .build("id", "body")
   .field("id", or(def("Identifier"), def("Literal")))
   .field("body", def("BlockStatement"));
+
+def("DeclareExportDeclaration")
+    .bases("Declaration")
+    .build("default", "declaration", "specifiers", "source")
+    .field("default", Boolean)
+    .field("declaration", or(
+        def("DeclareVariable"),
+        def("DeclareFunction"),
+        def("DeclareClass"),
+        def("Type"), // Implies default.
+        null
+    ))
+    .field("specifiers", [or(
+        def("ExportSpecifier"),
+        def("ExportBatchSpecifier")
+    )], defaults.emptyArray)
+    .field("source", or(
+        def("Literal"),
+        null
+    ), defaults["null"]);


### PR DESCRIPTION
Flow is adding `declare export` declarations, which are very similar to `export` declarations. Currently Flow outputs the esprima representation of `export` declarations, so the `declare export` declarations are modeled similarly. Hopefully we'll move this over to match estree and babel sometime soon.

@benjamn - is it a problem that this refers to nodes declared in `esprima.js`?