### PR TITLE
Added default behaviour to MemberExpression and a spec

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -305,7 +305,15 @@ def("MemberExpression")
     .build("object", "property", "computed")
     .field("object", def("Expression"))
     .field("property", or(def("Identifier"), def("Expression")))
-    .field("computed", Boolean, defaults["false"]);
+    .field("computed", Boolean, function(){
+        var type = this.property.type;
+        if (type === 'Literal' ||
+            type === 'MemberExpression' ||
+            type === 'BinaryExpression') {
+            return true;
+        }
+        return false;
+    });
 
 def("Pattern").bases("Node");
 

--- a/test/run.js
+++ b/test/run.js
@@ -2133,3 +2133,61 @@ describe("RegExpLiteral nodes", function() {
         assert.strictEqual(n.Literal.check(regExpLiteral, true), false);
     });
 });
+
+
+describe("MemberExpression", function() {
+    it("should set computed flag to false by default", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.identifier('bar')
+        )
+
+        assert.strictEqual(memberExpression.computed, false)
+    });
+
+    it("should not set computed to true if property is a callExpression", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.callExpression(b.identifier('bar'), [])
+        )
+
+        assert.strictEqual(memberExpression.computed, false)
+    });
+
+    it("should set computed flag to true if property is a literal", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.literal('bar')
+        )
+
+        assert.strictEqual(memberExpression.computed, true)
+    });
+
+    it("should set computed flag to true if property is a memberExpression", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.memberExpression(b.identifier('foo'), b.literal('bar'))
+        )
+
+        assert.strictEqual(memberExpression.computed, true)
+    });
+
+    it("should set computed flag to true if property is a binaryExpression", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.memberExpression(b.identifier('foo'), b.literal('bar'))
+        )
+
+        assert.strictEqual(memberExpression.computed, true)
+    });
+
+    it("should override computed value when passed as a third argument to the builder", function(){
+        var memberExpression = b.memberExpression(
+            b.identifier('foo'),
+            b.callExpression(b.identifier('bar'), []),
+            true
+        )
+
+        assert.strictEqual(memberExpression.computed, true);
+    });
+});


### PR DESCRIPTION
cc @benjamn this adds default behaviour to MemberExpression so that computed is set to true if property is a `Literal`, another `MemberExpression` or a `BinaryExpression`.