### PR TITLE
Add TypeAlias to scope::lookup()/declares()

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -34,7 +34,8 @@ function Scope(path, parentScope) {
         isGlobal: { value: !parentScope, enumerable: true },
         depth: { value: depth },
         parent: { value: parentScope },
-        bindings: { value: {} }
+        bindings: { value: {} },
+        types: { value: {} },
     });
 }
 
@@ -65,6 +66,11 @@ Sp.didScan = false;
 Sp.declares = function(name) {
     this.scan();
     return hasOwn.call(this.bindings, name);
+};
+
+Sp.declaresType = function(name) {
+    this.scan();
+    return hasOwn.call(this.types, name);
 };
 
 Sp.declareTemporary = function(prefix) {
@@ -115,7 +121,7 @@ Sp.scan = function(force) {
             // Empty out this.bindings, just in cases.
             delete this.bindings[name];
         }
-        scanScope(this.path, this.bindings);
+        scanScope(this.path, this.bindings, this.types);
         this.didScan = true;
     }
 };
@@ -125,7 +131,12 @@ Sp.getBindings = function () {
     return this.bindings;
 };
 
-function scanScope(path, bindings) {
+Sp.getTypes = function () {
+    this.scan();
+    return this.types;
+};
+
+function scanScope(path, bindings, scopeTypes) {
     var node = path.value;
     ScopeType.assert(node);
 
@@ -136,11 +147,11 @@ function scanScope(path, bindings) {
         addPattern(path.get("param"), bindings);
 
     } else {
-        recursiveScanScope(path, bindings);
+        recursiveScanScope(path, bindings, scopeTypes);
     }
 }
 
-function recursiveScanScope(path, bindings) {
+function recursiveScanScope(path, bindings, scopeTypes) {
     var node = path.value;
 
     if (path.parent &&
@@ -154,7 +165,7 @@ function recursiveScanScope(path, bindings) {
 
     } else if (isArray.check(node)) {
         path.each(function(childPath) {
-            recursiveScanChild(childPath, bindings);
+            recursiveScanChild(childPath, bindings, scopeTypes);
         });
 
     } else if (namedTypes.Function.check(node)) {
@@ -162,11 +173,14 @@ function recursiveScanScope(path, bindings) {
             addPattern(paramPath, bindings);
         });
 
-        recursiveScanChild(path.get("body"), bindings);
+        recursiveScanChild(path.get("body"), bindings, scopeTypes);
+
+    } else if (namedTypes.TypeAlias && namedTypes.TypeAlias.check(node)) {
+        addTypePattern(path.get("id"), scopeTypes);
 
     } else if (namedTypes.VariableDeclarator.check(node)) {
         addPattern(path.get("id"), bindings);
-        recursiveScanChild(path.get("init"), bindings);
+        recursiveScanChild(path.get("init"), bindings, scopeTypes);
 
     } else if (node.type === "ImportSpecifier" ||
                node.type === "ImportNamespaceSpecifier" ||
@@ -187,12 +201,12 @@ function recursiveScanScope(path, bindings) {
             if (childPath.value !== child) {
                 throw new Error("");
             }
-            recursiveScanChild(childPath, bindings);
+            recursiveScanChild(childPath, bindings, scopeTypes);
         });
     }
 }
 
-function recursiveScanChild(path, bindings) {
+function recursiveScanChild(path, bindings, scopeTypes) {
     var node = path.value;
 
     if (!node || Expression.check(node)) {
@@ -213,7 +227,7 @@ function recursiveScanChild(path, bindings) {
             // Any declarations that occur inside the catch body that do
             // not have the same name as the catch parameter should count
             // as bindings in the outer scope.
-            recursiveScanScope(path.get("body"), bindings);
+            recursiveScanScope(path.get("body"), bindings, scopeTypes);
 
             // If a new binding matching the catch parameter name was
             // created while scanning the catch body, ignore it because it
@@ -225,7 +239,7 @@ function recursiveScanChild(path, bindings) {
         }
 
     } else {
-        recursiveScanScope(path, bindings);
+        recursiveScanScope(path, bindings, scopeTypes);
     }
 }
 
@@ -278,9 +292,30 @@ function addPattern(patternPath, bindings) {
     }
 }
 
+function addTypePattern(patternPath, types) {
+    var pattern = patternPath.value;
+    namedTypes.Pattern.assert(pattern);
+
+    if (namedTypes.Identifier.check(pattern)) {
+        if (hasOwn.call(types, pattern.name)) {
+            types[pattern.name].push(patternPath);
+        } else {
+            types[pattern.name] = [patternPath];
+        }
+
+    }
+}
+
 Sp.lookup = function(name) {
     for (var scope = this; scope; scope = scope.parent)
         if (scope.declares(name))
+            break;
+    return scope;
+};
+
+Sp.lookupType = function(name) {
+    for (var scope = this; scope; scope = scope.parent)
+        if (scope.declaresType(name))
             break;
     return scope;
 };


### PR DESCRIPTION
Currently when looking up an Identifier that points to and TypeAlias it is not found by scope::lookup() or declares().

This PR adds TypeAlias to as valid target to the scope.

Example:

```js
type MyType = { x: string };

var foo: MyType = { x: "bar" };
```
The Identifier "MyType" of the TypeAnnotation in the variable declaration can now be looked up with this PR.

I also though about duplicate targets with this, but flow does not allow a TypeAlias to be named the same as a variable in the same scope, so no problem from this side.

This is needed for reactjs/react-docgen#48 which uses recast, so after this gets merged, it would be nice if you could create a new version of ast-type, and then of recast with this new version.

I tried creating a test, but couldn't get esprima to understand flow syntax.