### PR TITLE
Add support for NullLiteralTypeAnnotation

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -154,6 +154,10 @@ def("NullableTypeAnnotation")
   .build("typeAnnotation")
   .field("typeAnnotation", def("Type"));
 
+def("NullLiteralTypeAnnotation")
+  .bases("Type")
+  .build();
+
 def("FunctionTypeAnnotation")
   .bases("Type")
   .build("params", "returnType", "rest", "typeParameters")


### PR DESCRIPTION
Right now ast-types will throw on this syntax, because NullLiteralTypeAnnotation is not defined.

```js
type Foo = string | null;
```

This PR fixes the issue.