### PR TITLE
Fix default of object type call property.

### DIFF
--- a/def/fb-harmony.js
+++ b/def/fb-harmony.js
@@ -201,7 +201,7 @@ def("ObjectTypeCallProperty")
   .bases("Node")
   .build("value")
   .field("value", def("FunctionTypeAnnotation"))
-  .field("static", Boolean, false);
+  .field("static", Boolean, defaults["false"]);
 
 def("QualifiedTypeIdentifier")
   .bases("Node")


### PR DESCRIPTION
This fixes the default value for the `static` field in `ObjectTypeCallProperty`.