### PR TITLE
Add ExistsTypeAnnotation for Flow existential type annotations

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -68,6 +68,10 @@ def("ThisTypeAnnotation")
   .bases("Type")
   .build();
 
+def("ExistsTypeAnnotation")
+  .bases("Type")
+  .build();
+
 def("FunctionTypeAnnotation")
   .bases("Type")
   .build("params", "returnType", "rest", "typeParameters")


### PR DESCRIPTION
e.g. the `*` in `type Foo = Array<*>`