### PR TITLE
Pick up indexers correctly in ObjectTypeAnnotation (flow)

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -94,7 +94,7 @@ def("ArrayTypeAnnotation")
 
 def("ObjectTypeAnnotation")
   .bases("Type")
-  .build("properties")
+  .build("properties", "indexers", "callProperties")
   .field("properties", [def("ObjectTypeProperty")])
   .field("indexers", [def("ObjectTypeIndexer")], defaults.emptyArray)
   .field("callProperties",


### PR DESCRIPTION
Seems like the `field`s were added but the `build` spec hasn't been updated. Thanks!