### PR TITLE
[do not merge] scope refactor/cleanup + discuss

### DIFF
--- a/lib/equiv.js
+++ b/lib/equiv.js
@@ -1,3 +1,4 @@
+'use strict';
 var types = require("../main");
 var getFieldNames = types.getFieldNames;
 var getFieldValue = types.getFieldValue;

--- a/lib/node-path.js
+++ b/lib/node-path.js
@@ -1,3 +1,4 @@
+'use strict';
 var types = require("./types");
 var n = types.namedTypes;
 var b = types.builders;

--- a/lib/path-visitor.js
+++ b/lib/path-visitor.js
@@ -1,3 +1,4 @@
+'use strict';
 var types = require("./types");
 var NodePath = require("./node-path");
 var Printable = types.namedTypes.Printable;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,3 +1,4 @@
+'use strict';
 var Op = Object.prototype;
 var hasOwn = Op.hasOwnProperty;
 var types = require("./types");

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,18 +1,33 @@
+/**
+ * @exports Scope
+ */
+'use strict';
 var types = require("./types");
 var Type = types.Type;
 var namedTypes = types.namedTypes;
 var Node = namedTypes.Node;
 var Expression = namedTypes.Expression;
 var isArray = types.builtInTypes.array;
-var hasOwn = Object.prototype.hasOwnProperty;
+var has = require('has');
 var b = types.builders;
 
+/**
+ * Class that represents a set of variable bindings
+ * @class
+ * @public
+ * @property {Scope?} parent
+ * @property {Node} node
+ * @property {boolean} isGlobal
+ * @property {number} depth
+ * @property {Object} bindings
+ * @property {Object} types
+ */
 function Scope(path, parentScope) {
     if (!(this instanceof Scope)) {
         throw new Error("Scope constructor cannot be invoked without 'new'");
     }
     if (!(path instanceof require("./node-path"))) {
-        throw new Error("");
+        throw new Error("Scope path must be a NodePath");
     }
     ScopeType.assert(path.value);
 
@@ -20,7 +35,7 @@ function Scope(path, parentScope) {
 
     if (parentScope) {
         if (!(parentScope instanceof Scope)) {
-            throw new Error("");
+            throw new Error("Scope parentScope must be a Scope or null");
         }
         depth = parentScope.depth + 1;
     } else {
@@ -30,7 +45,14 @@ function Scope(path, parentScope) {
 
     Object.defineProperties(this, {
         path: { value: path },
-        node: { value: path.value },
+        node: {
+            get: function getNode() {
+                return path.value;
+            },
+            set: function setNode() {
+                throw Error("Cannot assign .node of a Scope");
+            }
+        },
         isGlobal: { value: !parentScope, enumerable: true },
         depth: { value: depth },
         parent: { value: parentScope },
@@ -54,29 +76,51 @@ var scopeTypes = [
 
 var ScopeType = Type.or.apply(Type, scopeTypes);
 
-Scope.isEstablishedBy = function(node) {
+/**
+ * Determines if the type of `node` establishes a new scope. This does not
+ * determine the type of scope that is established.
+ *
+ * @param {Node} node - Node to check for scoping
+ * @return {boolean}
+ */
+Scope.isEstablishedBy = function isEstablishedBy(node) {
     return ScopeType.check(node);
 };
 
-var Sp = Scope.prototype;
+/**
+ * Will be overridden after an instance lazily calls scanScope.
+ *
+ * This will be set to true to prevent scanning a Node multiple times.
+ */
+Scope.prototype.didScan = false;
 
-// Will be overridden after an instance lazily calls scanScope.
-Sp.didScan = false;
-
-Sp.declares = function(name) {
+/**
+ * Returns true if a Scope declares a variable with a specific name
+ *
+ * @param {string} name - Name of the variable to check
+ * @return {boolean}
+ */
+Scope.prototype.declares = function declares(name) {
     this.scan();
-    return hasOwn.call(this.bindings, name);
+    return has(this.bindings, name);
 };
 
-Sp.declaresType = function(name) {
+Scope.prototype.declaresType = function declaresType(name) {
     this.scan();
-    return hasOwn.call(this.types, name);
+    return has(this.types, name);
 };
 
-Sp.declareTemporary = function(prefix) {
+/**
+ * Produces a Node which has an identifier that is not declared by this or
+ * any parent of this Scope.
+ *
+ * @param {string} prefix - Name to prefix the variable identifier with
+ * @return {Node}
+ */
+Scope.prototype.declareTemporary = function declareTemporary(prefix) {
     if (prefix) {
         if (!/^[a-z$_]/i.test(prefix)) {
-            throw new Error("");
+            throw new Error("Prefix must be a valid start to a JS variable identifier");
         }
     } else {
         prefix = "t$";
@@ -97,11 +141,28 @@ Sp.declareTemporary = function(prefix) {
     return this.bindings[name] = types.builders.identifier(name);
 };
 
-Sp.injectTemporary = function(identifier, init) {
+/**
+ * Inserts a variable into the AST
+ *
+ * @param {Node} identifier - Identifier Node to insert
+ * @param {Node} init - Expression to initialize the identifier with
+ * @return {Node} identifier
+ */
+Scope.prototype.injectTemporary = function injectTemporary(identifier, init) {
     identifier || (identifier = this.declareTemporary());
 
+    // convert expression arrow function to block arrow function
+    if (namedTypes.Function.check(this.path.node)) {
+        if (this.path.node.expression) {
+            var body = types.builders.blockStatement();
+            body.body.unshift(this.path.node.body);
+            this.path.node.body = body;
+        }
+        this.path.node.expression = false;
+    }
     var bodyPath = this.path.get("body");
-    if (namedTypes.BlockStatement.check(bodyPath.value)) {
+    // some things can nest "body", Function => BlockStatement
+    while (!Array.isArray(bodyPath.value)) {
         bodyPath = bodyPath.get("body");
     }
 
@@ -115,28 +176,31 @@ Sp.injectTemporary = function(identifier, init) {
     return identifier;
 };
 
-Sp.scan = function(force) {
+/**
+ * @param {boolean} force - scan even if we have already scanned the path
+ */
+Scope.prototype.scan = function scan(force) {
     if (force || !this.didScan) {
         for (var name in this.bindings) {
             // Empty out this.bindings, just in cases.
             delete this.bindings[name];
         }
-        scanScope(this.path, this.bindings, this.types);
+        scanScope(this.path, this);
         this.didScan = true;
     }
 };
 
-Sp.getBindings = function () {
+Scope.prototype.getBindings = function getBindings() {
     this.scan();
     return this.bindings;
 };
 
-Sp.getTypes = function () {
+Scope.prototype.getTypes = function getTypes() {
     this.scan();
     return this.types;
 };
 
-function scanScope(path, bindings, scopeTypes) {
+function scanScope(path, scope) {
     var node = path.value;
     ScopeType.assert(node);
 
@@ -144,43 +208,43 @@ function scanScope(path, bindings, scopeTypes) {
         // A catch clause establishes a new scope but the only variable
         // bound in that scope is the catch parameter. Any other
         // declarations create bindings in the outer scope.
-        addPattern(path.get("param"), bindings);
+        addPattern(path.get("param"), scope.bindings);
 
     } else {
-        recursiveScanScope(path, bindings, scopeTypes);
+        recursiveScanScope(path, scope);
     }
 }
 
-function recursiveScanScope(path, bindings, scopeTypes) {
+function recursiveScanScope(path, scope) {
     var node = path.value;
 
     if (path.parent &&
         namedTypes.FunctionExpression.check(path.parent.node) &&
         path.parent.node.id) {
-        addPattern(path.parent.get("id"), bindings);
+        addPattern(path.parent.get("id"), scope.bindings);
     }
 
     if (!node) {
         // None of the remaining cases matter if node is falsy.
 
     } else if (isArray.check(node)) {
-        path.each(function(childPath) {
-            recursiveScanChild(childPath, bindings, scopeTypes);
+        path.each(function scanChildPath(childPath) {
+            recursiveScanChild(childPath, scope);
         });
 
     } else if (namedTypes.Function.check(node)) {
-        path.get("params").each(function(paramPath) {
-            addPattern(paramPath, bindings);
+        path.get("params").each(function addParam(paramPath) {
+            addPattern(paramPath, scope.bindings);
         });
 
-        recursiveScanChild(path.get("body"), bindings, scopeTypes);
+        recursiveScanChild(path.get("body"), scope);
 
     } else if (namedTypes.TypeAlias && namedTypes.TypeAlias.check(node)) {
-        addTypePattern(path.get("id"), scopeTypes);
+        addTypePattern(path.get("id"), scope.types);
 
     } else if (namedTypes.VariableDeclarator.check(node)) {
-        addPattern(path.get("id"), bindings);
-        recursiveScanChild(path.get("init"), bindings, scopeTypes);
+        addPattern(path.get("id"), scope.bindings);
+        recursiveScanChild(path.get("init"), scope);
 
     } else if (node.type === "ImportSpecifier" ||
                node.type === "ImportNamespaceSpecifier" ||
@@ -192,63 +256,68 @@ function recursiveScanScope(path, bindings, scopeTypes) {
             // ESTree/Acorn/ESpree use .local for all three node types.
             path.get(node.local ? "local" :
                      node.name ? "name" : "id"),
-            bindings
+            scope.bindings
         );
 
     } else if (Node.check(node) && !Expression.check(node)) {
-        types.eachField(node, function(name, child) {
+        types.eachField(node, function (name, child) {
             var childPath = path.get(name);
             if (childPath.value !== child) {
                 throw new Error("");
             }
-            recursiveScanChild(childPath, bindings, scopeTypes);
+            recursiveScanChild(childPath, scope);
         });
     }
 }
 
-function recursiveScanChild(path, bindings, scopeTypes) {
+function recursiveScanChild(path, scope) {
     var node = path.value;
 
     if (!node || Expression.check(node)) {
         // Ignore falsy values and Expressions.
 
     } else if (namedTypes.FunctionDeclaration.check(node)) {
-        addPattern(path.get("id"), bindings);
+        addPattern(path.get("id"), scope.bindings);
 
     } else if (namedTypes.ClassDeclaration &&
                namedTypes.ClassDeclaration.check(node)) {
-        addPattern(path.get("id"), bindings);
+        addPattern(path.get("id"), scope.bindings);
 
     } else if (ScopeType.check(node)) {
         if (namedTypes.CatchClause.check(node)) {
             var catchParamName = node.param.name;
-            var hadBinding = hasOwn.call(bindings, catchParamName);
+            var hadBinding = has(scope.bindings, catchParamName);
 
             // Any declarations that occur inside the catch body that do
             // not have the same name as the catch parameter should count
             // as bindings in the outer scope.
-            recursiveScanScope(path.get("body"), bindings, scopeTypes);
+            recursiveScanScope(path.get("body"), scope);
 
             // If a new binding matching the catch parameter name was
             // created while scanning the catch body, ignore it because it
             // actually refers to the catch parameter and not the outer
             // scope that we're currently scanning.
             if (!hadBinding) {
-                delete bindings[catchParamName];
+                delete scope.bindings[catchParamName];
             }
         }
 
     } else {
-        recursiveScanScope(path, bindings, scopeTypes);
+        recursiveScanScope(path, scope);
     }
 }
 
+/** looks up a pattern and adds it to bindings
+ *
+ * [x] => x
+ * {x: {y: z}} => z
+ */
 function addPattern(patternPath, bindings) {
     var pattern = patternPath.value;
     namedTypes.Pattern.assert(pattern);
 
     if (namedTypes.Identifier.check(pattern)) {
-        if (hasOwn.call(bindings, pattern.name)) {
+        if (has(bindings, pattern.name)) {
             bindings[pattern.name].push(patternPath);
         } else {
             bindings[pattern.name] = [patternPath];
@@ -256,7 +325,7 @@ function addPattern(patternPath, bindings) {
 
     } else if (namedTypes.ObjectPattern &&
                namedTypes.ObjectPattern.check(pattern)) {
-        patternPath.get('properties').each(function(propertyPath) {
+        patternPath.get('properties').each(function addPropertyPattern(propertyPath) {
             var property = propertyPath.value;
             if (namedTypes.Pattern.check(property)) {
                 addPattern(propertyPath, bindings);
@@ -270,7 +339,7 @@ function addPattern(patternPath, bindings) {
 
     } else if (namedTypes.ArrayPattern &&
                namedTypes.ArrayPattern.check(pattern)) {
-        patternPath.get('elements').each(function(elementPath) {
+        patternPath.get('elements').each(function addElementPattern(elementPath) {
             var element = elementPath.value;
             if (namedTypes.Pattern.check(element)) {
                 addPattern(elementPath, bindings);
@@ -297,7 +366,7 @@ function addTypePattern(patternPath, types) {
     namedTypes.Pattern.assert(pattern);
 
     if (namedTypes.Identifier.check(pattern)) {
-        if (hasOwn.call(types, pattern.name)) {
+        if (has(types, pattern.name)) {
             types[pattern.name].push(patternPath);
         } else {
             types[pattern.name] = [patternPath];
@@ -306,21 +375,29 @@ function addTypePattern(patternPath, types) {
     }
 }
 
-Sp.lookup = function(name) {
+/**
+ *
+ * @param {string} name - The name of the variable to search for.
+ * @return {Scope} The scope that declares `name`
+ */
+Scope.prototype.lookup = function lookup(name) {
     for (var scope = this; scope; scope = scope.parent)
         if (scope.declares(name))
             break;
     return scope;
 };
 
-Sp.lookupType = function(name) {
+Scope.prototype.lookupType = function lookupType(name) {
     for (var scope = this; scope; scope = scope.parent)
         if (scope.declaresType(name))
             break;
     return scope;
 };
 
-Sp.getGlobalScope = function() {
+/**
+ * @return {Scope}
+ */
+Scope.prototype.getGlobalScope = function getGlobalScope() {
     var scope = this;
     while (!scope.isGlobal)
         scope = scope.parent;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,15 +1,20 @@
 /**
  * @exports Scope
+ * @exports Scope.isEstablishedBy
  */
 'use strict';
+var has = require('has');
+
+var NodePath = require("./node-path");
+
 var types = require("./types");
+var b = types.builders;
+var isArray = types.builtInTypes.array;
 var Type = types.Type;
 var namedTypes = types.namedTypes;
+
 var Node = namedTypes.Node;
 var Expression = namedTypes.Expression;
-var isArray = types.builtInTypes.array;
-var has = require('has');
-var b = types.builders;
 
 /**
  * Class that represents a set of variable bindings
@@ -22,46 +27,56 @@ var b = types.builders;
  * @property {Object} bindings
  * @property {Object} types
  */
-function Scope(path, parentScope) {
-    if (!(this instanceof Scope)) {
-        throw new Error("Scope constructor cannot be invoked without 'new'");
-    }
-    if (!(path instanceof require("./node-path"))) {
-        throw new Error("Scope path must be a NodePath");
-    }
-    ScopeType.assert(path.value);
-
-    var depth;
-
-    if (parentScope) {
-        if (!(parentScope instanceof Scope)) {
-            throw new Error("Scope parentScope must be a Scope or null");
+class Scope {
+    constructor(path, parentScope) {
+        if (!(path instanceof NodePath)) {
+            throw new Error("Scope path must be a NodePath");
         }
-        depth = parentScope.depth + 1;
-    } else {
-        parentScope = null;
-        depth = 0;
+        ScopeType.assert(path.value);
+
+        var depth = 0;
+
+        if (parentScope) {
+            if (!(parentScope instanceof Scope)) {
+                throw new Error("Scope parentScope must be a Scope or null");
+            }
+            depth = parentScope.depth + 1;
+        } else {
+            parentScope = null;
+        }
+
+        Object.defineProperties(this, {
+            path: { value: path },
+            node: {
+                get: function getNode() {
+                    return path.value;
+                },
+                set: function setNode() {
+                    throw Error("Cannot assign .node of a Scope");
+                }
+            },
+            isGlobal: { value: !parentScope, enumerable: true },
+            depth: { value: depth },
+            parent: { value: parentScope },
+            bindings: { value: {} },
+            types: { value: {} },
+        });
     }
 
-    Object.defineProperties(this, {
-        path: { value: path },
-        node: {
-            get: function getNode() {
-                return path.value;
-            },
-            set: function setNode() {
-                throw Error("Cannot assign .node of a Scope");
-            }
-        },
-        isGlobal: { value: !parentScope, enumerable: true },
-        depth: { value: depth },
-        parent: { value: parentScope },
-        bindings: { value: {} },
-        types: { value: {} },
-    });
+    /**
+     * Determines if the type of `node` establishes a new scope. This does not
+     * determine the type of scope that is established.
+     *
+     * @param {Node} node - Node to check for scoping
+     * @return {boolean}
+     */
+    static isEstablishedBy(node) {
+        return ScopeType.check(node);
+    };
 }
 
-var scopeTypes = [
+
+const SCOPE_TYPES = [
     // Program nodes introduce global scopes.
     namedTypes.Program,
 
@@ -74,18 +89,7 @@ var scopeTypes = [
     namedTypes.CatchClause
 ];
 
-var ScopeType = Type.or.apply(Type, scopeTypes);
-
-/**
- * Determines if the type of `node` establishes a new scope. This does not
- * determine the type of scope that is established.
- *
- * @param {Node} node - Node to check for scoping
- * @return {boolean}
- */
-Scope.isEstablishedBy = function isEstablishedBy(node) {
-    return ScopeType.check(node);
-};
+var ScopeType = Type.or.apply(Type, SCOPE_TYPES);
 
 /**
  * Will be overridden after an instance lazily calls scanScope.
@@ -382,26 +386,25 @@ function addTypePattern(patternPath, types) {
  */
 Scope.prototype.lookup = function lookup(name) {
     for (var scope = this; scope; scope = scope.parent)
-        if (scope.declares(name))
-            break;
-    return scope;
+        if (scope.declares(name)) {
+            return scope;
+        }
 };
 
 Scope.prototype.lookupType = function lookupType(name) {
     for (var scope = this; scope; scope = scope.parent)
-        if (scope.declaresType(name))
-            break;
-    return scope;
+        if (scope.declaresType(name)) {
+            return scope;
+        }
 };
 
 /**
  * @return {Scope}
  */
 Scope.prototype.getGlobalScope = function getGlobalScope() {
-    var scope = this;
-    while (!scope.isGlobal)
-        scope = scope.parent;
-    return scope;
+    return this.isGlobal ?
+        this :
+        this.parent.getGlobalScope();
 };
 
 module.exports = Scope;

--- a/lib/scope/Scopes.js
+++ b/lib/scope/Scopes.js
@@ -1,0 +1,388 @@
+"use strict";
+/**
+ @exports GlobalScope
+ @exports BlockScope
+ @exports CatchScope
+ @exports FunctionScope
+ @exports ModuleScope
+ @exports createScopeFromPath
+ */
+const visit = require('../../').visit;
+const n = require('../types').namedTypes;
+const has = require('has');
+
+class Scope {
+  constructor(type, parent) {
+    this.type = type;
+    if (parent instanceof Scope) {
+      this.parent = parent;
+    }
+    else if (typeof parent === 'function') {
+      Object.defineProperty(this, `parent`, {
+        get: parent
+      });
+    }
+    else {
+      this.parent = null;
+    }
+    this.bindings = Object.create(null);
+    this.types = Object.create(null);
+    Object.freeze(this);
+  }
+
+  hasOwnBinding(name) {
+    return has(this.bindings, name);
+  }
+  hasOwnType(name) {
+    return has(this.types, name);
+  }
+  addBinding(path, kind) {
+    if (this.acceptedVariableKinds.indexOf(kind) >= 0) {
+      let bind;
+      if (kind === 'type') {
+        bind = (name, idPath) => {
+          if (!this.hasOwnType(name)) {
+            this.types[name] = idPath;
+            return;
+          }
+          throw Error(`Type for ${kind} ${name} already exists.`);
+        }
+      }
+      else {
+        bind = (name, idPath) => {
+          if (!this.hasOwnBinding(name)) {
+            this.bindings[name] = [idPath];
+            return;
+          }
+          this.bindings[name].push(idPath);
+          //throw Error(`Variable for ${kind} ${name} already exists.`);
+        }
+      }
+      addPattern(path, bind);
+      return this;
+    }
+    else if (this.parent) {
+      return this.parent.addBinding(path, kind);
+    }
+    throw Error(`No scope in chain accepts variable kind: ${kind}.`)
+  }
+
+  lookupBinding(name, kind) {
+    if (this.hasOwnBinding(name)) {
+      if (!kind || this.acceptedVariableKinds.indexOf(kind) >= 0) {
+        return this;
+      }
+    }
+    if (this.parent) {
+      return this.parent.lookupBinding(name, kind);
+    }
+    throw Error(`No scope in chain has variable ${kind?`${kind} `:``}${name}.`)
+  }
+}
+
+// special, it doesn't have a path, since it doesn't have a parent
+const GlobalScope = class GlobalScope extends Scope {
+  constructor() {
+    super(`GlobalScope`, null);
+  }
+
+  /**
+   Global scopes are never introduced by a path.
+   */
+  static introducedByPath(path) {
+    return false;
+  }
+}
+GlobalScope.prototype.acceptedVariableKinds = Object.freeze([
+  `var`, `let`, `const`, `type`
+]);
+
+const BlockScope = class BlockScope extends Scope {
+  constructor(getParent) {
+    super(`BlockScope`, getParent);
+  }
+
+  /**
+   * Block statements sometimes nest in places we don't want
+   * to introduce scopes at
+   * * Function => BlockStatement
+   * * Program => BlockStatement
+   *
+   * NOTE: CatchClause introduces 2 scopes! 1 Catch 1 Block
+   * visible by doing:
+   *
+   * try {} catch (e) {
+   *   let e;  * e doesn't complain about redefinition
+   * }
+   */
+  static introducedByPath(path) {
+    if (n.BlockStatement.check(path.node)) {
+      if (!path.parent) {
+        throw Error(`Unsure of scoping of BlockStatement without parent. Function and Program could be the real Scope.`);
+      }
+      const parent = path.parent.node;
+      if (!n.Function.check(parent) && 
+        !n.Program.check(parent)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+BlockScope.prototype.acceptedVariableKinds = Object.freeze([
+  `let`, `const`
+]);
+
+const CatchScope = class CatchScope extends Scope {
+  constructor(getParent) {
+    super(`CatchScope`, getParent);
+  }
+
+  static introducedByPath(path) {
+    return n.CatchClause.check(path.node);
+  }
+}
+CatchScope.prototype.acceptedVariableKinds = Object.freeze([
+  `catch`
+]);
+const FunctionScope = class FunctionScope extends Scope {
+  constructor(getParent) {
+    super(`FunctionScope`, getParent);
+  }
+
+  static introducedByPath(path) {
+    return n.Function.check(path.node);
+  }
+}
+FunctionScope.prototype.acceptedVariableKinds = Object.freeze([
+  `var`, `let`, `const`, `param`, `type`
+]);
+
+const ModuleScope = class ModuleScope extends Scope {
+  constructor(getParent) {
+    super(`FunctionScope`, getParent);
+  }
+
+  /**
+   Module scopes are never introduced by a path.
+   */
+  static introducedByPath(path) {
+    return false;
+  }
+}
+ModuleScope.prototype.acceptedVariableKinds = Object.freeze([
+  `var`, `let`, `const`, `import`, `type`
+]);
+
+// Points to check for bailing out of scan and
+// Points to add variables to current scope
+//
+// @private
+const SCANNERS = {
+  visitNode: null,
+  visitFunction(path, currentScope) {
+    for (let i = 0; i < path.node.params.length; i++) {
+      currentScope.addBinding(path.get('params', i), 'function');
+    }
+  },
+  visitVariableDeclaration(path, currentScope) {
+    for (let i = 0; i < path.node.declarations.length; i++) {
+      currentScope.addBinding(path.get('declarations', i, 'id'), path.node.kind);
+    }
+  },
+  visitCatchClause(path, currentScope) {
+    currentScope.addBinding(path.get('param'), 'catch');
+  },
+  visitImportDeclaration(path, currentScope) {
+    for (let i = 0; i < path.node.specifiers.length; i++) {
+      currentScope.addBinding(path.get('specifiers', i, 'local'), 'import');
+    }
+  }
+};
+
+/**
+ * @param {Scope} root - should be a GlobalScope, FunctionScope, or ModuleScope
+ */
+function createScopeSpace(root) {
+  const scanned = new Set;
+  const found = new Map;
+
+  const from = (path) => createScopeFromPath(path, root, found);
+  const scan = (path) => {
+      const result = from(path);
+      if (scanned.has(result.path.node)) {
+        return result;
+      }
+      const ret = scanScope(path, root, found);
+      scanned.add(ret.path.node);
+      return ret;
+  }
+  return {
+    scan,
+    from
+  }
+}
+
+/**
+ Gets the scope for a path, then walks its children. Will stop once it encounters a scope that cannot leak into this scope (nested Functions for
+ example).
+ */
+function scanScope(startPath, root, memoCache) {
+  const result = createScopeFromPath(startPath, root, memoCache);
+  const scope = result.scope;
+  const stopOn = [];
+  function shouldStop(path) {
+    if (path.node === result.path.node) return false;
+    return stopOn.some(t => t.introducedByPath(path));
+  }
+  if (scope instanceof GlobalScope ||
+    scope instanceof ModuleScope ||
+    scope instanceof FunctionScope
+  ) {
+    stopOn.push(FunctionScope);
+  }
+  else if (scope instanceof BlockScope ||
+    scope instanceof CatchScope) {
+    stopOn.push(BlockScope, CatchScope);
+  }
+  else {
+    throw Error(`Unknown Scope type for ${scope}`);
+  }
+  const visitors = Object.keys(SCANNERS).reduce((acc, key) => {
+    const handler = SCANNERS[key];
+    acc[key] = function (path) {
+      if (shouldStop(path)) {
+        return false;
+      }
+      this.traverse(path);
+      if (handler !== null) {
+        const currentScope = createScopeFromPath(path, root, memoCache);
+        handler(path, currentScope.scope);
+      }
+    }
+    return acc;
+  }, Object.create(null));
+  visit(result.path.node, visitors);
+  return result;
+}
+
+/**
+ Scripts should set root to be a GlobalScope
+ ES Modules should set root to be a ModuleScope
+ CJS/AMD Modules should set root to be a FunctionScope
+ `root` could have parent scope setup to a shared GlobalScope
+
+ Generates a new Scope for the closest parent of `path`. If a Program is
+ found the `root` is returned instead since different source wrappers (AMD,
+ Browser, CJS, ES Modules, etc.) have differing scoping rules at top level.
+
+ Use the cache to memoize
+
+ @param {NodePath} path
+ @param {Scope|void} root
+ @param {}
+ @param {Map<AST, Scope>} cache
+ */
+function createScopeFromPath(path, root, cache) {
+  while (path) {
+    if (cache.has(path.node)) {
+      return cache.get(path.node);
+    }
+    if (n.Program.check(path.node)) {
+      const ret = {
+        path,
+        scope: root
+      };
+      cache.set(path.node, ret);
+      return ret;
+    }
+    const scopeType = [
+      FunctionScope,
+      BlockScope,
+      CatchScope
+    ].find(type => type.introducedByPath(path));
+    if (scopeType) {
+      let memod = false;
+      let memo;
+      const scope = new scopeType(
+        () => {
+          if (memod) return memo;
+          memod = true;
+          return memo = createScopeFromPath(path.parent, root, cache);
+        }
+      );
+      const ret = {
+        path,
+        scope
+      };
+      cache.set(path.node, ret);
+      return ret;
+    }
+    path = path.parent;
+  }
+  throw Error(`No scope found, no Program in AST?`);
+}
+
+function addPattern(path, onBind) {
+  const node = path.node;
+    if (n.Identifier.check(node)) {
+      onBind(node.name, path);
+    } else if (n.ObjectPattern.check(node)) {
+      path.get('properties').each(propertyPath => {
+        const property = propertyPath.value;
+        if (n.Pattern.check(property)) {
+          addPattern(propertyPath, onBind);
+        } else if (n.Property.check(property)) {
+          addPattern(propertyPath.get('value'), onBind);
+        } else if (n.SpreadProperty.check(property)) {
+          addPattern(propertyPath.get('argument'), onBind);
+        }
+      });
+    } else if (n.ArrayPattern.check(node)) {
+      path.get('elements').each(elementPath => {
+        const element = elementPath.value;
+        if (n.Pattern.check(element)) {
+          addPattern(elementPath, onBind);
+        } else if (n.SpreadElement.check(element)) {
+          addPattern(elementPath.get("argument"), onBind);
+        }
+      });
+    } else if (n.PropertyPattern.check(node)) {
+      addPattern(path.get('pattern'), onBind);
+    } else if (n.SpreadElementPattern.check(node) ||
+               n.SpreadPropertyPattern.check(node)) {
+      addPattern(path.get('argument'), onBind);
+    } else if (n.RestElement.check(node)) {
+      addPattern(path.get("argument"), onBind);
+    }
+    else {
+      throw Error(`Unknown pattern type ${path.value}`);
+    }
+}
+
+
+const ast_a = require('esprima').parse(`var a;`);
+const ast_b = require('esprima').parse(`var b;`);
+const ast_c = require('esprima').parse(`var c;`);
+const realm = new GlobalScope;
+const space = createScopeSpace(realm);
+visit(ast_a, {
+  visitProgram(path) {
+    space.scan(path);
+    return false;
+  }
+});
+visit(ast_b, {
+  visitProgram(path) {
+    space.scan(path);
+    return false;
+  } 
+});
+// DON'T SCAN C
+visit(ast_c, {
+  visitProgram(path) {
+    // space.scan(path);
+    return false;
+  } 
+});
+console.log(realm);

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,3 +1,4 @@
+'use strict';
 var types = require("../lib/types");
 var Type = types.Type;
 var builtin = types.builtInTypes;

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,3 +1,4 @@
+'use strict';
 var Ap = Array.prototype;
 var slice = Ap.slice;
 var map = Ap.map;
@@ -676,7 +677,6 @@ function getFieldValue(object, fieldName) {
             return field.getValue(object);
         }
     }
-
     return object[fieldName];
 }
 exports.getFieldValue = getFieldValue;

--- a/package.json
+++ b/package.json
@@ -27,13 +27,18 @@
   "license": "MIT",
   "main": "main.js",
   "scripts": {
+    "doc": "jsdoc -t $(npm explore minami pwd) -r lib",
     "test": "mocha --reporter spec --full-trace test/run.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "has": "1.0.1"
+  },
   "devDependencies": {
     "babel-core": "^5.6.15",
     "esprima": "~1.2.2",
     "esprima-fb": "~14001.1.0-dev-harmony-fb",
+    "jsdoc": "3.4.0",
+    "minami": "1.1.1",
     "mocha": "~2.2.5"
   },
   "engines": {


### PR DESCRIPTION
Leaving this here for discussion purposes while I start work. These are somewhat breaking changes that I will be going over the reason why on each.

Plan:
1. have "kind" on scopes: Global, Object (`with` like), Block, Function, Catch, Module corresponding to EnvironmentRecords in spec
   
   This aids in some features like `let`/`const` being supported, and would avoid the strange add/delete of binding for Catch scopes. New path would be for code to have knowledge of what scope types variables can bind to.
   
   | kind | types |
   | --- | --- |
   | var | Function,Global,Module |
   | let | Block,Function,Global,Module |
   | const | Block,Function,Global,Module |
   | params | Function |
   | catch | Catch |
   | import | Module |
   
   This would change the scanning code since it would scan all the children that could affect the parent scope, namely this means only scopes that can hold all kinds of variables would stop a scan (Function,Global, and Module)
2. Setup Global scope in `.visit(ast, visitors, {globalScope:})`
   
   this would mean that you could reuse global scopes between visits and share a global scope between ASTs.
3. Upgrade to newer JS, supported by Node v4+
4. JSDoc
