### PR TITLE
fix: fixes error in scope traversal

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -198,7 +198,9 @@ function recursiveScanScope(path, bindings, scopeTypes) {
     } else if (Node.check(node) && !Expression.check(node)) {
         types.eachField(node, function(name, child) {
             var childPath = path.get(name);
-            if (childPath.value !== child) {
+            if (childPath.value !== child &&
+                    !(Array.isArray(childPath.value) && Array.isArray(child) &&
+                    childPath.value.length === 0 && child.length === 0)) {
                 throw new Error("");
             }
             recursiveScanChild(childPath, bindings, scopeTypes);


### PR DESCRIPTION
If childPath.value and child are both 'default' array they are not of
the same instance, but we must not throw an error in this case.