### PR TITLE
Babel 6 types

### DIFF
--- a/def/babel6.js
+++ b/def/babel6.js
@@ -1,0 +1,134 @@
+module.exports = function (fork) {
+    fork.use(require("./babel"));
+    fork.use(require("./flow"));
+
+    // var types = fork.types;
+    var types = fork.use(require("../lib/types"));
+    // var defaults = fork.shared.defaults;
+    var defaults = fork.use(require("../lib/shared")).defaults;
+    var def = types.Type.def;
+    var or = types.Type.or;
+
+    def("Directive")
+        .bases("Node")
+        .build("value")
+        .field("value", def("DirectiveLiteral"));
+
+    def("DirectiveLiteral")
+        .bases("Node", "Expression")
+        .build("value")
+        .field("value", String, defaults["use strict"]);
+
+    def("BlockStatement")
+        .bases("Statement")
+        .build("body")
+        .field("body", [def("Statement")])
+        .field("directives", [def("Directive")], defaults.emptyArray);
+
+    def("Program")
+        .bases("Node")
+        .build("body")
+        .field("body", [def("Statement")])
+        .field("directives", [def("Directive")], defaults.emptyArray);
+
+    // Split Literal
+    def("StringLiteral")
+        .bases("Literal")
+        .build("value")
+        .field("value", String);
+
+    def("NumericLiteral")
+        .bases("Literal")
+        .build("value")
+        .field("value", Number);
+
+    def("NullLiteral")
+        .bases("Literal")
+        .build();
+
+    def("BooleanLiteral")
+        .bases("Literal")
+        .build("value")
+        .field("value", Boolean);
+
+    def("RegExpLiteral")
+        .bases("Literal")
+        .build("pattern", "flags")
+        .field("pattern", String)
+        .field("flags", String);
+
+    // Split Property -> ObjectProperty and ObjectMethod
+    def("ObjectExpression")
+        .bases("Expression")
+        .build("properties")
+        .field("properties", [or(def("Property"), def("ObjectMethod"), def("ObjectProperty"), def("SpreadProperty"))]);
+
+    // ObjectMethod hoist .value properties to own properties
+    def("ObjectMethod")
+        .bases("Node", "Function")
+        .build("kind", "key", "params", "body", "computed")
+        .field("kind", or("method", "get", "set"))
+        .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
+        .field("params", [def("Pattern")])
+        .field("body", def("BlockStatement"))
+        .field("computed", Boolean, defaults["false"])
+        .field("generator", Boolean, defaults["false"])
+        .field("async", Boolean, defaults["false"])
+        .field("decorators",
+            or([def("Decorator")], null),
+            defaults["null"]);
+
+    def("ObjectProperty")
+        .bases("Node")
+        .build("key", "value")
+        .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
+        .field("value", or(def("Expression"), def("Pattern")))
+        .field("computed", Boolean, defaults["false"]);
+
+    // MethodDefinition -> ClassMethod
+    def("ClassBody")
+        .bases("Declaration")
+        .build("body")
+        .field("body", [or(def("ClassMethod"), def("ClassProperty"))]);
+
+    def("ClassMethod")
+        .bases("Declaration", "Function")
+        .build("kind", "key", "params", "body", "computed", "static")
+        .field("kind", or("get", "set", "method", "constructor"))
+        .field("key", or(def("Literal"), def("Identifier"), def("Expression")))
+        .field("params", [def("Pattern")])
+        .field("body", def("BlockStatement"))
+        .field("computed", Boolean, defaults["false"])
+        .field("static", Boolean, defaults["false"])
+        .field("generator", Boolean, defaults["false"])
+        .field("async", Boolean, defaults["false"])
+        .field("decorators",
+            or([def("Decorator")], null),
+            defaults["null"]);
+
+    // Split into RestProperty and SpreadProperty
+    def("ObjectPattern")
+        .bases("Pattern")
+        .build("properties")
+        .field("properties", [or(def("Property"), def("RestProperty"), def("ObjectProperty"))])
+        .field("decorators", [def("Decorator")]);
+
+    def("SpreadProperty")
+      .bases("Node")
+      .build("argument")
+      .field("argument", def("Expression"));
+
+    def("RestProperty")
+      .bases("Node")
+      .build("argument")
+      .field("argument", def("Expression"));
+
+    def("ForAwaitStatement")
+      .bases("Statement")
+      .build("left", "right", "body")
+      .field("left", or(
+          def("VariableDeclaration"),
+          def("Expression")))
+      .field("right", def("Expression"))
+      .field("body", def("Statement"));
+};

--- a/def/flow.js
+++ b/def/flow.js
@@ -13,6 +13,10 @@ module.exports = function (fork) {
       .bases("Type")
       .build();
 
+    def("EmptyTypeAnnotation")
+      .bases("Type")
+      .build();
+
     def("MixedTypeAnnotation")
       .bases("Type")
       .build();
@@ -68,7 +72,7 @@ module.exports = function (fork) {
     def("NullTypeAnnotation")
       .bases("Type")
       .build();
-    
+
     def("ThisTypeAnnotation")
       .bases("Type")
       .build();
@@ -76,7 +80,11 @@ module.exports = function (fork) {
     def("ExistsTypeAnnotation")
       .bases("Type")
       .build();
-    
+
+    def("ExistentialTypeParam")
+      .bases("Type")
+      .build();
+
     def("FunctionTypeAnnotation")
       .bases("Type")
       .build("params", "returnType", "rest", "typeParameters")
@@ -111,14 +119,20 @@ module.exports = function (fork) {
       .build("key", "value", "optional")
       .field("key", or(def("Literal"), def("Identifier")))
       .field("value", def("Type"))
-      .field("optional", Boolean);
+      .field("optional", Boolean)
+      .field("variance",
+        or("plus", "minus", null),
+        defaults["null"]);
 
     def("ObjectTypeIndexer")
       .bases("Node")
       .build("id", "key", "value")
       .field("id", def("Identifier"))
       .field("key", def("Type"))
-      .field("value", def("Type"));
+      .field("value", def("Type"))
+      .field("variance",
+        or("plus", "minus", null),
+        defaults["null"]);
 
     def("ObjectTypeCallProperty")
       .bases("Node")
@@ -186,7 +200,7 @@ module.exports = function (fork) {
       .field("bound",
         or(def("TypeAnnotation"), null),
         defaults["null"]);
-    
+
     def("Function")
       .field("returnType",
         or(def("TypeAnnotation"), null),
@@ -199,7 +213,10 @@ module.exports = function (fork) {
       .build("key", "value", "typeAnnotation", "static")
       .field("value", or(def("Expression"), null))
       .field("typeAnnotation", or(def("TypeAnnotation"), null))
-      .field("static", Boolean, defaults["false"]);
+      .field("static", Boolean, defaults["false"])
+      .field("variance",
+        or("plus", "minus", null),
+        defaults["null"]);
 
     def("ClassImplements")
       .field("typeParameters",
@@ -267,6 +284,11 @@ module.exports = function (fork) {
       .build("id", "body")
       .field("id", or(def("Identifier"), def("Literal")))
       .field("body", def("BlockStatement"));
+
+    def("DeclareModuleExports")
+      .bases("Statement")
+      .build("typeAnnotation")
+      .field("typeAnnotation", def("Type"));
 
     def("DeclareExportDeclaration")
       .bases("Declaration")

--- a/main.js
+++ b/main.js
@@ -12,5 +12,6 @@ module.exports = require('./fork')([
     require("./def/jsx"),
     require("./def/flow"),
     require("./def/esprima"),
-    require("./def/babel")
+    require("./def/babel"),
+    require("./def/babel6")
 ]);

--- a/test/run.js
+++ b/test/run.js
@@ -1264,6 +1264,11 @@ describe("array and object pattern scope", function() {
     // ObjectPattern with Property and SpreadProperty
     // ArrayPattern with SpreadElement
     describe("esprima", function() {
+        var types = require('../fork')([
+            require("../def/esprima")
+        ]);
+        var b = types.builders;
+
         var objectPattern;
         var arrayPattern;
 
@@ -1321,6 +1326,14 @@ describe("array and object pattern scope", function() {
     // ObjectPattern with PropertyPattern and SpreadPropertyPattern
     // ArrayPatterhn with SpreadElementPattern
     describe("Mozilla Parser API", function() {
+        var types = require('../fork')([
+            require("../def/core"),
+            require("../def/es6"),
+            require("../def/es7"),
+            require("../def/mozilla"),
+        ]);
+        var b = types.builders;
+
         var objectPattern;
         var arrayPattern;
 


### PR DESCRIPTION
Fixes https://github.com/benjamn/ast-types/issues/132
For babel pr: https://github.com/babel/babel/pull/3561
Also ref https://github.com/benjamn/recast/pull/298

First 3 commits are from https://github.com/benjamn/ast-types/pull/145 (fixed merge conflicts by preferring the changes in the PR).

You can review that PR or this one with whitespace off for a better diff https://github.com/benjamn/ast-types/pull/162/files?w=1.

My commit adds the babel 6 types (not sure if it's right though, so please review!).

References:
- babel-types definitions: https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions
- babylon ast differences https://github.com/babel/babylon#output

cc @jamestalmage @benjamn 
