### PR TITLE
Add DeclareModuleExports (Flow AST)

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -287,4 +287,9 @@ module.exports = function (fork) {
         def("Literal"),
         null
       ), defaults["null"]);
+
+    def("DeclareModuleExports")
+      .bases("Statement")
+      .build("typeAnnotation")
+      .field("typeAnnotation", def("TypeAnnotation"));
 };


### PR DESCRIPTION
Encountered in flow-parser's test fixtures.
Definition basically lifted from [facebook/flow/.../custom_ast_types.js](https://github.com/facebook/flow/blob/master/src/parser/test/custom_ast_types.js).
