### PR TITLE
Fixes error in Espree scope scanning

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -232,7 +232,7 @@ module.exports = function (fork) {
             // Ignore falsy values and Expressions.
 
         } else if (namedTypes.FunctionDeclaration.check(node) &&
-          path.get("id") !== null) {
+                   node.id !== null) {
             addPattern(path.get("id"), bindings);
 
         } else if (namedTypes.ClassDeclaration &&

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -231,7 +231,8 @@ module.exports = function (fork) {
         if (!node || Expression.check(node)) {
             // Ignore falsy values and Expressions.
 
-        } else if (namedTypes.FunctionDeclaration.check(node)) {
+        } else if (namedTypes.FunctionDeclaration.check(node) &&
+          path.get("id") !== null) {
             addPattern(path.get("id"), bindings);
 
         } else if (namedTypes.ClassDeclaration &&
@@ -345,6 +346,6 @@ module.exports = function (fork) {
             scope = scope.parent;
         return scope;
     };
-    
+
     return Scope;
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-core": "^5.6.15",
+    "espree": "^3.1.7",
     "esprima": "~1.2.2",
     "esprima-fb": "~14001.1.0-dev-harmony-fb",
     "mocha": "~2.5.3"

--- a/test/run.js
+++ b/test/run.js
@@ -1122,6 +1122,7 @@ describe("scope methods", function () {
         var names;
 
         var ast = require("espree").parse([
+            "var zap;",
             "export default function(zom) {",
             "    var innerFn = function(zip) {};",
             "    return innerFn(zom);",
@@ -1133,8 +1134,8 @@ describe("scope methods", function () {
 
         types.visit(ast, {
             visitFunctionDeclaration: function(path) {
-                names = Object.keys(path.scope.lookup("zom").getBindings()).sort();
-                assert.deepEqual(names, ["innerFn", "zom"]);
+                names = Object.keys(path.scope.lookup("zap").getBindings()).sort();
+                assert.deepEqual(names, ["zap"]);
                 this.traverse(path);
             }
         });

--- a/test/run.js
+++ b/test/run.js
@@ -1133,11 +1133,11 @@ describe("scope methods", function () {
 
         types.visit(ast, {
             visitFunctionDeclaration: function(path) {
-                names = Object.keys(path.lookup("zom").getBindings()).sort();
+                names = Object.keys(path.scope.lookup("zom").getBindings()).sort();
                 assert.deepEqual(names, ["innerFn", "zom"]);
                 this.traverse(path);
             }
-        }); // bump for Travis-CI build
+        });
     });
 
     it("should inject temporary into current scope", function() {

--- a/test/run.js
+++ b/test/run.js
@@ -1118,6 +1118,28 @@ describe("scope methods", function () {
         assert.deepEqual(names, ["x", "xyDefault", "xyNamespace", "z"]);
     });
 
+    it("should work for ES6 syntax (espree)", function() {
+        var names;
+
+        var ast = require("espree").parse([
+            "export default function(zom) {",
+            "    var innerFn = function(zip) {};",
+            "    return innerFn(zom);",
+            "};"
+        ].join("\n"), {
+            sourceType: "module",
+            ecmaVersion: 6
+        });
+
+        types.visit(ast, {
+            visitFunctionDeclaration: function(path) {
+                names = Object.keys(path.lookup("zom").getBindings()).sort();
+                assert.deepEqual(names, ["innerFn", "zom"]);
+                this.traverse(path);
+            }
+        });
+    });
+
     it("should inject temporary into current scope", function() {
         var ast = parse(scope.join("\n"));
         var bindings;

--- a/test/run.js
+++ b/test/run.js
@@ -1137,7 +1137,7 @@ describe("scope methods", function () {
                 assert.deepEqual(names, ["innerFn", "zom"]);
                 this.traverse(path);
             }
-        });
+        }); // bump for Travis-CI build
     });
 
     it("should inject temporary into current scope", function() {


### PR DESCRIPTION
Parsing ECMAScript with ESLint's Espree parser results in function declarations with a nullable id property (i.e. anonymous function declarations). In particular cases, this causes an assertion failure when scanning scope bindings.

The new test reproduces the bug, and the patch to scope.js proposes a potential fix.