### PR TITLE
Provide missing importKind field definition on ImportDeclaration

### DIFF
--- a/def/esprima.js
+++ b/def/esprima.js
@@ -90,7 +90,9 @@ module.exports = function (fork) {
       .field("importKind", or(
         "value",
         "type"
-      ), defaults["value"]);
+      ), function() {
+        return "value";
+      });
 
     def("Block")
       .bases("Comment")

--- a/def/esprima.js
+++ b/def/esprima.js
@@ -80,13 +80,17 @@ module.exports = function (fork) {
 
     def("ImportDeclaration")
       .bases("Declaration")
-      .build("specifiers", "source")
+      .build("specifiers", "source", "importKind")
       .field("specifiers", [or(
         def("ImportSpecifier"),
         def("ImportNamespaceSpecifier"),
         def("ImportDefaultSpecifier")
       )], defaults.emptyArray)
-      .field("source", def("Literal"));
+      .field("source", def("Literal"))
+      .field("importKind", or(
+        "value",
+        "type"
+      ), defaults["value"]);
 
     def("Block")
       .bases("Comment")

--- a/test/run.js
+++ b/test/run.js
@@ -35,6 +35,20 @@ describe("basic type checking", function() {
         assert.ok(n.Expression.check(ifFoo.test));
         assert.ok(n.Identifier.check(ifFoo.test));
         assert.ok(!n.Statement.check(ifFoo.test));
+        assert.equal(
+          b.importDeclaration(
+            [b.importDefaultSpecifier(b.identifier("foo"))], b.literal("bar")
+          ).importKind,
+          "value"
+        );
+        assert.throws(function () {
+            b.importDeclaration(
+              [b.importDefaultSpecifier(b.identifier("foo"))],
+              b.literal("bar"),
+              "baz"
+            )
+          }
+        );
         assert.ok(n.ImportDeclaration.check(
           b.importDeclaration(
             [b.importDefaultSpecifier(b.identifier("foo"))], b.literal("bar"),
@@ -43,8 +57,7 @@ describe("basic type checking", function() {
         );
         assert.ok(n.ImportDeclaration.check(
           b.importDeclaration(
-            [b.importNamespaceSpecifier(b.identifier("foo"))], b.literal("bar"),
-              "type")
+            [b.importNamespaceSpecifier(b.identifier("foo"))], b.literal("bar"))
           )
         );
     });

--- a/test/run.js
+++ b/test/run.js
@@ -37,12 +37,14 @@ describe("basic type checking", function() {
         assert.ok(!n.Statement.check(ifFoo.test));
         assert.ok(n.ImportDeclaration.check(
           b.importDeclaration(
-            [b.importDefaultSpecifier(b.identifier("foo"))], b.literal("bar"))
+            [b.importDefaultSpecifier(b.identifier("foo"))], b.literal("bar"),
+              "type")
           )
         );
         assert.ok(n.ImportDeclaration.check(
           b.importDeclaration(
-            [b.importNamespaceSpecifier(b.identifier("foo"))], b.literal("bar"))
+            [b.importNamespaceSpecifier(b.identifier("foo"))], b.literal("bar"),
+              "type")
           )
         );
     });


### PR DESCRIPTION
Imports can be inflected with a kind value:

``` javascript
import a from 'b';
import type c from 'b';
```

Whereas recast supports passing in a value for an `importKind` field on an `ImportDeclaration` node, ast-types lacks this field definition: https://github.com/benjamn/recast/blob/master/lib/printer.js#L480

I added the field and limited the allowed values to the strings "value" and "type". I don't know of any proposed analogs to "type", so for now it seems fine to just hardcode the two values instead of supporting a literal. 
