### PR TITLE
Flow: Add ObjectTypeAnnotation.exact

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -104,7 +104,8 @@ module.exports = function (fork) {
       .field("indexers", [def("ObjectTypeIndexer")], defaults.emptyArray)
       .field("callProperties",
         [def("ObjectTypeCallProperty")],
-        defaults.emptyArray);
+        defaults.emptyArray)
+      .field("exact", Boolean, defaults["false"]);
 
     def("ObjectTypeProperty")
       .bases("Node")


### PR DESCRIPTION
This reflects new syntax introduced in Flow 0.32.0.

References: [Flow 0.32.0 release notes](https://github.com/facebook/flow/releases/tag/v0.32.0), [Flow's parser test suite](https://github.com/facebook/flow/blob/master/src/parser/test/custom_ast_types.js#L70).

I don't know what the policy is on builder signatures in `ast-types`, so I did not add `exact` as a builder argument.
