### PR TITLE
types.getFieldValue shouldn't assert on undefined

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -681,7 +681,7 @@ module.exports = function () {
             }
         }
 
-        return object[fieldName];
+        return object && object[fieldName];
     }
     exports.getFieldValue = getFieldValue;
 

--- a/test/run.js
+++ b/test/run.js
@@ -311,6 +311,13 @@ describe("types.getFieldValue", function() {
             []
         );
     });
+
+    it("should handle undefined objects", function() {
+        assert.equal(
+            types.getFieldValue(undefined, "name"),
+            undefined
+        );
+    });
 });
 
 describe("types.eachField", function() {


### PR DESCRIPTION
I'm writing some `jscodeshift` transforms & it uses this fantastic library :+1:

Unfortunately, when using `NodePath.get()` it becomes easy to footgun yourself and call `.getValueProperty()` on undefined values which then explode.

``` js
// Currently I have to do this
// otherwise the second check explodes if the node doesn't exist
p.get("callee", "object").value &&
p.get("callee", "object").getValueProperty("name") === "m"

// After the PR I can do this, .getValueProperty will return undefined 
// and the comparison fails as expected without asserting
p.get("callee", "object").getValueProperty("name") === "m"
```

as I add more conditions to more fields the repetition gets worse and worse. I did some looking through the tests/examples and couldn't see any obvious alternative to this pattern, so I wrote a small PR to try and reduce the pain.

I modified `types.getFieldValue` so that in the fallback case where the type can't be identified it requires that the object passed in at least be truthy before it tries to reference a property on it. If necessary I'd be happy to bump up the complexity of the check, I'm not 100% sure what the coding standards are in this lib & saw boolean return usage elsewhere so assumed it was ok.
