### PR TITLE
Default decorator to null in ObjectPattern

### DIFF
--- a/def/babel6.js
+++ b/def/babel6.js
@@ -111,7 +111,9 @@ module.exports = function (fork) {
         .bases("Pattern")
         .build("properties")
         .field("properties", [or(def("Property"), def("RestProperty"), def("ObjectProperty"))])
-        .field("decorators", [def("Decorator")]);
+        .field("decorators",
+            or([def("Decorator")], null),
+            defaults["null"]);
 
     def("SpreadProperty")
       .bases("Node")


### PR DESCRIPTION
Fixes `no value or default function given for field "decorators" of ObjectPattern("properties": [Property | RestProperty | ObjectProperty])` when using `recast.types.builders.objectPattern([])`.

This might definitely not be the right fix as I'm a total AST noob, but it fixes my breaking tests after updating to recast `0.11.16`.