### PR TITLE
Add optional name attribute to File node

### DIFF
--- a/def/core.js
+++ b/def/core.js
@@ -36,8 +36,9 @@ module.exports = function (fork) {
 
     def("File")
         .bases("Node")
-        .build("program")
-        .field("program", def("Program"));
+        .build("program", "name")
+        .field("program", def("Program"))
+        .field("name", or(String, null), defaults["null"]);
 
     def("Program")
         .bases("Node")


### PR DESCRIPTION
This PR will add an optional `name` attribute to the File node to represent the source filename.

### Use Case:
When using `recast` to perform a transformation on a large codebase, it is especially convenient to keep the source filename within the AST itself. This allows a functionally pure approach to reading and writing ASTs, e.g.

```
loadAST('myFile.js')
  .then(file => transform(file))
  .then(file => saveAST(file.name, file));
```

Storing the filename on the Node prevents the consumer from having to store any state externally about the AST and its original location. This is especially useful when there are a large number of files and ASTs involved.

A great bonus feature of keeping the filename within the AST is that recast will also store `file.original.name` which allows file renames to be part of the transformation.

This ties in nicely with the `sourceFileName` parser option that is already passed into `recast.parse`. I've filed a PR adding a passthrough of `sourceFileName` to `b.file`, it can be found at https://github.com/benjamn/recast/pull/354.