### PR TITLE
Add Flow's DeclareExportAllDeclaration type

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -310,4 +310,12 @@ module.exports = function (fork) {
         def("Literal"),
         null
       ), defaults["null"]);
+
+    def("DeclareExportAllDeclaration")
+      .bases("Declaration")
+      .build("source")
+      .field("source", or(
+        def("Literal"),
+        null
+      ), defaults["null"]);
 };


### PR DESCRIPTION
Flow has a node type `DeclareExportAllDeclaration` that is generated from this code:

```js
declare export * from "foo.js"
```

This PR adds this node type.