### PR TITLE
add Babel's NumericLiteralTypeAnnotation

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -35,6 +35,14 @@ module.exports = function (fork) {
       .field("value", Number)
       .field("raw", String);
 
+    // Babylon 6 differs in AST from Flow
+    // same as NumberLiteralTypeAnnotation
+    def("NumericLiteralTypeAnnotation")
+      .bases("Type")
+      .build("value", "raw")
+      .field("value", Number)
+      .field("raw", String);
+
     def("StringTypeAnnotation")
       .bases("Type")
       .build();


### PR DESCRIPTION
Flow's parser names it `NumberLiteralTypeAnnotation`, but Babylon currently names `NumericLiteralTypeAnnotation` ([it's being renamed for v7](https://github.com/babel/babylon/issues/329)).

Found this was missing when using `prettier`.