### PR TITLE
Add typeAnnotation to ObjectPattern in flow

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -189,6 +189,9 @@ module.exports = function (fork) {
     def("Identifier")
       .field("typeAnnotation", or(def("TypeAnnotation"), null), defaults["null"]);
 
+    def("ObjectPattern")
+      .field("typeAnnotation", or(def("TypeAnnotation"), null), defaults["null"]);
+
     def("TypeParameterDeclaration")
       .bases("Node")
       .build("params")


### PR DESCRIPTION
When investigating https://github.com/prettier/prettier/issues/1007, it turns out that `types.getFieldNames(node)` for a node of type `ObjectPattern` doesn't return `typeAnnotation` and therefore it doesn't show up in the traversal for comment location.

I've patched this in my `node_modules/` folder and it fixes the comment location. Let me know if you need anything else to ensure that this is good.