### PR TITLE
sync definitions with latest babel-types: `"babel-types": "^6.26.0"`. Added DeclareOpaqueType and OpaqueType.

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -267,9 +267,21 @@ module.exports = function (fork) {
       .field("typeParameters", or(def("TypeParameterDeclaration"), null))
       .field("right", def("Type"));
 
+    def("OpaqueType")
+      .bases("Declaration")
+      .build("id", "typeParameters", "impltype", "supertype")
+      .field("id", def("Identifier"))
+      .field("typeParameters", or(def("TypeParameterDeclaration"), null))
+      .field("implType", def("Type"))
+      .field("superType", def("Type"));
+
     def("DeclareTypeAlias")
       .bases("TypeAlias")
       .build("id", "typeParameters", "right");
+
+    def("DeclareOpaqueType")
+      .bases("TypeAlias")
+      .build("id", "typeParameters", "supertype");
 
     def("TypeCastExpression")
       .bases("Expression")

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "babel-types": "^6.23.0",
+    "babel-types": "^6.26.0",
     "babylon": "^6.16.1",
     "espree": "^3.1.7",
     "esprima": "~4.0.0",


### PR DESCRIPTION
As stated in the subject line: `npm test` failed on the updated babel-types and now it passes all tests once again.