### PR TITLE
Fixes lack of support for ObjectTypeSpreadProperty in ObjectTypeProperty properties

### DIFF
--- a/def/flow.js
+++ b/def/flow.js
@@ -116,7 +116,7 @@ module.exports = function (fork) {
     def("ObjectTypeAnnotation")
       .bases("Type")
       .build("properties", "indexers", "callProperties")
-      .field("properties", or(def("ObjectTypeProperty"), def("ObjectTypeSpreadProperty")))
+      .field("properties", [or(def("ObjectTypeProperty"), def("ObjectTypeSpreadProperty"))])
       .field("indexers", [def("ObjectTypeIndexer")], defaults.emptyArray)
       .field("callProperties",
         [def("ObjectTypeCallProperty")],

--- a/def/flow.js
+++ b/def/flow.js
@@ -116,7 +116,7 @@ module.exports = function (fork) {
     def("ObjectTypeAnnotation")
       .bases("Type")
       .build("properties", "indexers", "callProperties")
-      .field("properties", [def("ObjectTypeProperty")])
+      .field("properties", or(def("ObjectTypeProperty"), def("ObjectTypeSpreadProperty")))
       .field("indexers", [def("ObjectTypeIndexer")], defaults.emptyArray)
       .field("callProperties",
         [def("ObjectTypeCallProperty")],


### PR DESCRIPTION
I think it was somehow missed when ObjectTypeSpreadProperty support was first added, which is odd because this is the only place ObjectTypeSpreadProperty could actually be used: http://astexplorer.net/#/gist/fd19e271d1c2ef14b2720f695ea01ce3/3b91af647e3bbfdb3d3ac1757ff16fbbc4a30ccd