### PR TITLE
Add function AssignmentPattern to function scope

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -274,6 +274,10 @@ module.exports = function (fork) {
                 bindings[pattern.name] = [patternPath];
             }
 
+        } else if (namedTypes.AssignmentPattern &&
+          namedTypes.AssignmentPattern.check(pattern)) {
+          addPattern(patternPath.get('left'), bindings);
+
         } else if (namedTypes.ObjectPattern &&
           namedTypes.ObjectPattern.check(pattern)) {
             patternPath.get('properties').each(function(propertyPath) {


### PR DESCRIPTION
Default funtion arguments are compiled by bable into AssignmentPattern.
We need to add it into scope for lookup.