### PR TITLE
Base `Noop` node on `Statement` to match `EmptyStatement` behavior.

### DIFF
--- a/def/babel-core.js
+++ b/def/babel-core.js
@@ -7,7 +7,7 @@ module.exports = function (fork) {
   var or = types.Type.or;
 
   def("Noop")
-    .bases("Node")
+    .bases("Statement")
     .build();
 
   def("DoExpression")


### PR DESCRIPTION
Recast treats them as effectively the same for printing purposes, so in order to prevent recast from crashing on `Noop` nodes when printing we need to treat them as statements. See https://github.com/square/babel-codemod/issues/43.