### PR TITLE
Re-sync `package-lock.json` after reify was updated.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -292,22 +292,14 @@
       "dev": true
     },
     "reify": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.12.3.tgz",
-      "integrity": "sha512-s13k0kuZbhBzeRoJQGomWnLj2y10wK3FYXRXbZoydowAMmY0jTiFN98TgLkaE8uZkVCaoq3djnDo7mksWLsx4g==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.13.7.tgz",
+      "integrity": "sha512-jA6C/TdOf0g1A9WlQL7enh8yfGXgCmU3qbOpgc98vzRNEgu4TrAnSGec+uLxHdci96lftdBow3q0X3pbXnzmGQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "minizlib": "1.0.4",
         "semver": "5.4.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
-          "dev": true
-        }
       }
     },
     "semver": {


### PR DESCRIPTION
`package.json` has `^0.13.1` vs. `package-lock.json` which had `0.12.3`, so an `npm install` re-wrote it to use `0.13.7`.