### PR TITLE
definition for numeric literal extra

### DIFF
--- a/def/babel-core.js
+++ b/def/babel-core.js
@@ -136,7 +136,17 @@ module.exports = function (fork) {
   def("NumericLiteral")
     .bases("Literal")
     .build("value")
-    .field("value", Number);
+    .field("value", Number)
+    .field("raw", or(String, null), defaults["null"])
+    .field("extra", {
+      rawValue: Number,
+      raw: String
+    }, function getDefault() {
+      return {
+        rawValue: this.value,
+        raw: this.value + ""
+      }
+    });
 
   def("BigIntLiteral")
     .bases("Literal")


### PR DESCRIPTION
This is part of a fix for benjamn/Recast#457

The information necessary print numeric literals parsed by babylon without converting them is part of the extra field.