### PR TITLE
fix #266. 

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -8,10 +8,14 @@ BAB_TAG=v$(node -p 'require("babylon/package.json").version')
 
 if [ ! -d babylon ]
 then
+	if [ -d /tmp/babel ]
+	then
+    	rm -rf /tmp/babel
+	fi
     git clone --branch "$BAB_TAG" --depth 1 \
-        https://github.com/babel/babel.git
-    mv babel/packages/babylon .
-    rm -rf babel
+        https://github.com/babel/babel.git /tmp/babel
+    mv /tmp/babel/packages/babylon .
+    rm -rf /tmp/babel
 fi
 
 # Hard-code this for now.
@@ -19,10 +23,14 @@ TS_TAG=v2.7.2
 
 if [ ! -d typescript-compiler ]
 then
+	if [ -d /tmp/TypeScript ]
+	then
+    	rm -rf /tmp/TypeScript
+    fi
     git clone --branch "$TS_TAG" --depth 1 \
-        https://github.com/Microsoft/TypeScript.git
-    mv TypeScript/src/compiler typescript-compiler
-    rm -rf TypeScript
+        https://github.com/Microsoft/TypeScript.git /tmp/TypeScript
+    mv /tmp/TypeScript/src/compiler typescript-compiler
+    rm -rf /tmp/TypeScript
 fi
 
 cd .. # back to the ast-types/test/ directory


### PR DESCRIPTION
Also, the code in `run.sh` makes sure the target directories in /tmp/ are cleaned before both repos are cloned in there to ensure nothing untoward gets into /test/data/
