### PR TITLE
fix #267

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "main.js",
   "scripts": {
-    "test": "test/run.sh"
+    "test": "bash -c test/run.sh"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
The adjusted npm script task `npm test` works on both Windows and UNIX boxes now. See #267.
