### PR TITLE
Add `?.` and `??` stage 1 nodes

### DIFF
--- a/def/es-proposals.js
+++ b/def/es-proposals.js
@@ -1,0 +1,33 @@
+module.exports = function (fork) {
+  fork.use(require('./core'));
+
+  var types = fork.use(require("../lib/types"));
+  var Type = types.Type;
+  var def = types.Type.def;
+  var or = Type.or;
+
+  var shared = fork.use(require("../lib/shared"));
+  var defaults = shared.defaults;
+
+
+  // https://github.com/tc39/proposal-optional-chaining
+  // `a?.b` as per https://github.com/estree/estree/issues/146
+  def("OptionalMemberExpression")
+    .bases("MemberExpression")
+    .build("object", "property", "computed", "optional")
+    .field("optional", Boolean, defaults["true"])
+
+  // a?.b()
+  def("OptionalCallExpression")
+    .bases("CallExpression")
+    .build("callee", "arguments", "optional")
+    .field("optional", Boolean, defaults["true"])
+
+
+  // https://github.com/tc39/proposal-nullish-coalescing
+  // `a ?? b` as per https://github.com/babel/babylon/pull/761/files
+  var LogicalOperator = or("||", "&&", "??");
+
+  def("LogicalExpression")
+    .field("operator", LogicalOperator)
+};

--- a/main.js
+++ b/main.js
@@ -13,5 +13,6 @@ module.exports = require('./fork')([
   require("./def/flow"),
   require("./def/esprima"),
   require("./def/babel"),
-  require("./def/typescript")
+  require("./def/typescript"),
+  require("./def/es-proposals")
 ]);

--- a/test/ecmascript.js
+++ b/test/ecmascript.js
@@ -2337,3 +2337,70 @@ describe("MemberExpression", function() {
     assert.strictEqual(memberExpression.computed, true);
   });
 });
+
+describe("Optional Chaining", function() {
+  describe('OptionalMemberExpression', function() {
+    it("should set optional to true by default", function(){
+      var optionalMemberExpression = b.optionalMemberExpression(
+        b.identifier('foo'),
+        b.identifier('bar')
+      );
+
+      assert.strictEqual(optionalMemberExpression.optional, true);
+    });
+
+    it("should allow optional to be false", function(){
+      var optionalMemberExpression = b.optionalMemberExpression(
+        b.identifier('foo'),
+        b.identifier('bar'),
+        true,
+        false
+      );
+
+      assert.strictEqual(optionalMemberExpression.optional, false);
+    });
+  });
+
+  describe('OptionalCallExpression', function() {
+    it("should set optional to true by default", function(){
+      var optionalCallExpression = b.optionalCallExpression(
+        b.identifier('foo'),
+        []
+      );
+
+      assert.strictEqual(optionalCallExpression.optional, true);
+    });
+
+    it("should allow optional to be false", function(){
+      var optionalCallExpression = b.optionalCallExpression(
+        b.identifier('foo'),
+        [],
+        false
+      );
+
+      assert.strictEqual(optionalCallExpression.optional, false);
+    });
+  });
+});
+
+describe('Nullish Coalescing Operator', function() {
+  it('should allow `??` as operator', function() {
+    var logicalExpression = b.logicalExpression(
+      "??",
+      b.identifier("a"),
+      b.identifier("b")
+    );
+
+    assert.strictEqual(logicalExpression.operator, "??");
+  });
+
+  it('should not allow `crap` as operator', function() {
+    assert.throws(function() {
+      b.logicalExpression(
+        "crap",
+        b.identifier("a"),
+        b.identifier("b")
+      );
+    }, "does not match field \"operator\"");
+  });
+});


### PR DESCRIPTION
Add support for stage 1 proposals "Optional Chaining" (`?.`) and "Nullish Coalescing" (`??`) operators.

This adds the following nodes;

- `OptionalMemberExpression` (for `a?.b` and `a?.[b]`)
- `OptionalCallExpression` (for `a.b()` and `a?.[b]()`)

It adds an option to `LogicalExpression` to allow `??` as the `operator`.

Tests have been added.