### PR TITLE
Correct capitalization of supertype and impltype

### DIFF
--- a/def/flow.ts
+++ b/def/flow.ts
@@ -294,8 +294,8 @@ export default function (fork: Fork) {
     .build("id", "typeParameters", "impltype", "supertype")
     .field("id", def("Identifier"))
     .field("typeParameters", or(def("TypeParameterDeclaration"), null))
-    .field("implType", def("FlowType"))
-    .field("superType", def("FlowType"));
+    .field("impltype", def("FlowType"))
+    .field("supertype", def("FlowType"));
 
   def("DeclareTypeAlias")
     .bases("TypeAlias")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -1851,15 +1851,17 @@ export interface TypeAliasBuilder {
 export interface OpaqueTypeBuilder {
   (
     id: K.IdentifierKind,
-    typeParameters: K.TypeParameterDeclarationKind | null
+    typeParameters: K.TypeParameterDeclarationKind | null,
+    impltype: K.FlowTypeKind,
+    supertype: K.FlowTypeKind
   ): N.OpaqueType;
   from(
     params: {
       comments?: K.CommentKind[] | null,
       id: K.IdentifierKind,
-      implType: K.FlowTypeKind,
+      impltype: K.FlowTypeKind,
       loc?: K.SourceLocationKind | null,
-      superType: K.FlowTypeKind,
+      supertype: K.FlowTypeKind,
       typeParameters: K.TypeParameterDeclarationKind | null
     }
   ): N.OpaqueType;

--- a/gen/nodes.ts
+++ b/gen/nodes.ts
@@ -864,8 +864,8 @@ export interface OpaqueType extends Omit<Declaration, "type"> {
   type: "OpaqueType";
   id: K.IdentifierKind;
   typeParameters: K.TypeParameterDeclarationKind | null;
-  implType: K.FlowTypeKind;
-  superType: K.FlowTypeKind;
+  impltype: K.FlowTypeKind;
+  supertype: K.FlowTypeKind;
 }
 
 export interface DeclareTypeAlias extends Omit<TypeAlias, "type"> {


### PR DESCRIPTION
The flow AST calls these fields `supertype` and `impltype` (as opposed to `superType` and `implType`). See the [ast tab](https://flow.org/try/#0PYBwhgjgrgpgBAFwJ4ngFQFxwN4F84C8OuA3EA) here.

This prevents tools like recast from traversing these fields, which means tools like jscodeshift won't codemod them appropriately. This was quite the bug to track down :D 