### PR TITLE
fix(scope): add TypeParameterDeclarations and InterfaceDeclarations to scope.types

### DIFF
--- a/lib/path.ts
+++ b/lib/path.ts
@@ -11,9 +11,9 @@ export interface Path<V = any> {
   __childCache: object | null;
   getValueProperty(name: any): any;
   get(...names: any[]): any;
-  each(callback: any, context: any): any;
-  map(callback: any, context: any): any;
-  filter(callback: any, context: any): any;
+  each(callback: any, context?: any): any;
+  map(callback: any, context?: any): any;
+  filter(callback: any, context?: any): any;
   shift(): any;
   unshift(...args: any[]): any;
   push(...args: any[]): any;


### PR DESCRIPTION
fix #294
fix #296

### Important Note
With this change, `NodePaths` for `ClassDeclaration`s, `ClassExpression`s, `InterfaceDeclaration`s, and `TypeAlias`es will create their own `Scope`.  *But*, when `scanScope` sees that the node is one of those, rather than a `Program`, `Function`, or `CatchClause`, it will only scan and add `TypeParameter`s to the `scope.types` -- it won't touch `scope.bindings`.