### PR TITLE
Avoid skipping `conditional-infer` validation test.

### DIFF
--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -31,11 +31,8 @@ glob("**/input.js", {
 
     files.forEach((tsPath: any) => {
       var fullPath = path.join(babelTSFixturesDir, tsPath);
-      // Until https://github.com/babel/babel/pull/7967 is released:
-      var shouldSkip = tsPath.endsWith("conditional-infer/input.js");
 
-      (shouldSkip ? xit : it)
-      ("should validate " + path.relative(pkgRootDir, fullPath), function (done) {
+      it("should validate " + path.relative(pkgRootDir, fullPath), function (done) {
         fs.readFile(fullPath, "utf8", function (error, code) {
           if (error) {
             throw error;


### PR DESCRIPTION
babel/babel#7967 has been released since @babel/parser@v7.0.0-beta.48.

Ref. 9777ef7f23bb881a5b7619214fe8db17922dec5c