### PR TITLE
Remove legacy E4X operator.

### DIFF
--- a/def/core.ts
+++ b/def/core.ts
@@ -246,7 +246,7 @@ export default function (fork: Fork) {
         "+", "-", "*", "/", "%", "**",
         "&", // TODO Missing from the Parser API.
         "|", "^", "in",
-        "instanceof", "..");
+        "instanceof");
 
     def("BinaryExpression")
         .bases("Expression")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -474,7 +474,7 @@ export interface UnaryExpressionBuilder {
 
 export interface BinaryExpressionBuilder {
   (
-    operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof" | "..",
+    operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof",
     left: K.ExpressionKind,
     right: K.ExpressionKind
   ): N.BinaryExpression;
@@ -483,7 +483,7 @@ export interface BinaryExpressionBuilder {
       comments?: K.CommentKind[] | null,
       left: K.ExpressionKind,
       loc?: K.SourceLocationKind | null,
-      operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof" | "..",
+      operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof",
       right: K.ExpressionKind
     }
   ): N.BinaryExpression;

--- a/gen/nodes.ts
+++ b/gen/nodes.ts
@@ -251,7 +251,7 @@ export interface UnaryExpression extends Omit<Expression, "type"> {
 
 export interface BinaryExpression extends Omit<Expression, "type"> {
   type: "BinaryExpression";
-  operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof" | "..";
+  operator: "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "in" | "instanceof";
   left: K.ExpressionKind;
   right: K.ExpressionKind;
 }


### PR DESCRIPTION
Since #303 removed the legacy Mozilla and E4X AST definitions, the legacy `..` operator should be removed as well.

Closes #238.