### PR TITLE
Add ClassProperty.access to specify field access

### DIFF
--- a/def/typescript.ts
+++ b/def/typescript.ts
@@ -450,6 +450,11 @@ export default function (fork: Fork) {
     .field("parameter", or(def("Identifier"),
                            def("AssignmentPattern")));
 
+  def("ClassProperty")
+    .field("access", // Not "accessibility"?
+           or("public", "private", "protected", void 0),
+           defaults["undefined"])
+
   // Defined already in es6 and babel-core.
   def("ClassBody")
     .field("body", [or(

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -871,6 +871,7 @@ export interface ClassPropertyBuilder {
   ): N.ClassProperty;
   from(
     params: {
+      access?: "public" | "private" | "protected" | undefined,
       comments?: K.CommentKind[] | null,
       computed?: boolean,
       key: K.LiteralKind | K.IdentifierKind | K.ExpressionKind,
@@ -2433,6 +2434,7 @@ export interface ClassPrivatePropertyBuilder {
   (key: K.PrivateNameKind, value?: K.ExpressionKind | null): N.ClassPrivateProperty;
   from(
     params: {
+      access?: "public" | "private" | "protected" | undefined,
       comments?: K.CommentKind[] | null,
       computed?: boolean,
       key: K.PrivateNameKind,

--- a/gen/nodes.ts
+++ b/gen/nodes.ts
@@ -427,6 +427,7 @@ export interface ClassProperty extends Omit<Declaration, "type"> {
   static: boolean;
   typeAnnotation: K.TypeAnnotationKind | K.TSTypeAnnotationKind | null;
   variance: K.VarianceKind | "plus" | "minus" | null;
+  access: "public" | "private" | "protected" | undefined;
 }
 
 export interface ClassBody extends Omit<Declaration, "type"> {


### PR DESCRIPTION
Currently the **ast-types** library can represent access modifiers for TypeScript methods and properties, but not for fields.  For example:

```ts
class Thing {
  // We can make this "public":
  public initialize(): void {
    this._isInitialized = true;
  }

  // We can make this "public":
  public get isInitialized(): boolean {
    return this._isInitialized;
  }

  // Suppose we want to make this "protected".  There is no way to specify
  // the access modifier.  By default it will be public.
  _isInitialized: boolean = false;
}
```

This PR allows you to emit the `protected` keyword like this:
```ts
protected _isInitialized: boolean = false;
```

The node builder uses the `access` parameter like this:

```ts
const fieldMember = recast.types.builders.classProperty.from({
  key: astBuilders.identifier('_isInitialized'),
  access: 'protected', // <--- specify access
  value: false
});
```

It uses the same notation that is already supported for methods/properties:
```ts
const propertyMember = recast.types.builders.classMethod.from({
  kind: 'get',
  key: astBuilders.identifier('isInitialized'),
  access: 'public', // <--- specify access
  params: []
});
```
