### PR TITLE
Add missing 'typeAnnotation' argument to TSAsExpression builder

### DIFF
--- a/def/typescript.ts
+++ b/def/typescript.ts
@@ -70,7 +70,7 @@ export default function (fork: Fork) {
 
   def("TSAsExpression")
     .bases("Expression", "Pattern")
-    .build("expression")
+    .build("expression", "typeAnnotation")
     .field("expression", def("Expression"))
     .field("typeAnnotation", def("TSType"))
     .field("extra",

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -2599,7 +2599,7 @@ export interface TSTypeReferenceBuilder {
 }
 
 export interface TSAsExpressionBuilder {
-  (expression: K.ExpressionKind): namedTypes.TSAsExpression;
+  (expression: K.ExpressionKind, typeAnnotation: K.TSTypeKind): namedTypes.TSAsExpression;
   from(
     params: {
       comments?: K.CommentKind[] | null,


### PR DESCRIPTION
The original issue in `jscodeshift` https://github.com/facebook/jscodeshift/issues/314