### PR TITLE
[Flow] Explicit Type Arguments for call and new

### DIFF
--- a/def/flow.ts
+++ b/def/flow.ts
@@ -380,4 +380,16 @@ export default function (fork: Fork) {
     .bases("FlowPredicate")
     .build("value")
     .field("value", def("Expression"));
+
+  def("CallExpression")
+    .field("typeArguments", or(
+      null,
+      def("TypeParameterInstantiation"),
+    ), defaults["null"]);
+
+  def("NewExpression")
+    .field("typeArguments", or(
+      null,
+      def("TypeParameterInstantiation"),
+    ), defaults["null"]);
 };

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -580,7 +580,8 @@ export interface NewExpressionBuilder {
       arguments: (K.ExpressionKind | K.SpreadElementKind)[],
       callee: K.ExpressionKind,
       comments?: K.CommentKind[] | null,
-      loc?: K.SourceLocationKind | null
+      loc?: K.SourceLocationKind | null,
+      typeArguments?: null | K.TypeParameterInstantiationKind
     }
   ): namedTypes.NewExpression;
 }
@@ -595,7 +596,8 @@ export interface CallExpressionBuilder {
       arguments: (K.ExpressionKind | K.SpreadElementKind)[],
       callee: K.ExpressionKind,
       comments?: K.CommentKind[] | null,
-      loc?: K.SourceLocationKind | null
+      loc?: K.SourceLocationKind | null,
+      typeArguments?: null | K.TypeParameterInstantiationKind
     }
   ): namedTypes.CallExpression;
 }
@@ -3362,7 +3364,8 @@ export interface OptionalCallExpressionBuilder {
       callee: K.ExpressionKind,
       comments?: K.CommentKind[] | null,
       loc?: K.SourceLocationKind | null,
-      optional?: boolean
+      optional?: boolean,
+      typeArguments?: null | K.TypeParameterInstantiationKind
     }
   ): namedTypes.OptionalCallExpression;
 }

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -297,12 +297,14 @@ export namespace namedTypes {
     type: "NewExpression";
     callee: K.ExpressionKind;
     arguments: (K.ExpressionKind | K.SpreadElementKind)[];
+    typeArguments?: null | K.TypeParameterInstantiationKind;
   }
 
   export interface CallExpression extends Omit<Expression, "type"> {
     type: "CallExpression";
     callee: K.ExpressionKind;
     arguments: (K.ExpressionKind | K.SpreadElementKind)[];
+    typeArguments?: null | K.TypeParameterInstantiationKind;
   }
 
   export interface RestElement extends Omit<Pattern, "type"> {

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -57,6 +57,34 @@ describe("flow types", function () {
     assert.strictEqual(program.body[0].typeAnnotation.type, 'TypeAnnotation');
   });
 
+  it("Explicit type arguments", function () {
+    const parser = {
+      parse(code: string) {
+        return flowParser.parse(code, {
+          types: true
+        });
+      }
+    };
+
+    const program = parser.parse([
+      'test<A>();',
+      'test<B, C>();',
+      'new test<D>();',
+      'new test<E, F>();',
+    ].join("\n"));
+    
+    const typeParamNames: any[] = []
+
+    types.visit(program, {
+      visitGenericTypeAnnotation(path: any) {
+        typeParamNames.push(path.node.id.name);
+        this.traverse(path);
+      }
+    });
+
+    assert.deepEqual(typeParamNames, ["A", "B", "C", "D", "E", "F"]);
+  });
+
   describe('scope', () => {
     const scope = [
       "type Foo = {}",


### PR DESCRIPTION
[Flow 0.72.0](https://github.com/facebook/flow/releases/tag/v0.72.0) added support for explicit type arguments (`test<ExplicitTypeArgumentGoesHere>`), but no one made a PR to ast-types.

Flow represents explicit type arguments as fields on the `CallExpression` and `NewExpression` nodes. The type of the field is a `TypeParameterInstantiation`.

I added some additional fields to `CallExpression` and `NewExpression` in Flow's definitions. I regenerated the autogen files and added a test to make sure I don't have any typos.

Let me know if I can do anything else to make this easier to review.