### PR TITLE
Add Flow type imports to scope types, not bindings

### DIFF
--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -219,15 +219,16 @@ export default function scopePlugin(fork: Fork) {
     } else if (node.type === "ImportSpecifier" ||
       node.type === "ImportNamespaceSpecifier" ||
       node.type === "ImportDefaultSpecifier") {
-      addPattern(
-        // Esprima used to use the .name field to refer to the local
-        // binding identifier for ImportSpecifier nodes, but .id for
-        // ImportNamespaceSpecifier and ImportDefaultSpecifier nodes.
-        // ESTree/Acorn/ESpree use .local for all three node types.
-        path.get(node.local ? "local" :
-        node.name ? "name" : "id"),
-        bindings
-      );
+      // Esprima used to use the .name field to refer to the local
+      // binding identifier for ImportSpecifier nodes, but .id for
+      // ImportNamespaceSpecifier and ImportDefaultSpecifier nodes.
+      // ESTree/Acorn/ESpree use .local for all three node types.
+      const idPath = path.get(node.local ? "local" : node.name ? "name" : "id");
+      if (node.importKind === 'type' || path.parent.node.importKind === 'type') {
+        addTypePattern(idPath, scopeTypes);
+      } else {
+        addPattern(idPath, bindings);
+      }
 
     } else if (Node.check(node) && !Expression.check(node)) {
       types.eachField(node, function(name: any, child: any) {

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -88,7 +88,10 @@ describe("flow types", function () {
   describe('scope', () => {
     const scope = [
       "type Foo = {}",
-      "interface Bar {}"
+      "interface Bar {}",
+      "import type ImportedFoo from './foo'",
+      "import type {OtherBar as ImportedBar} from './bar'",
+      "import {type ImportedBaz} from './baz'",
     ];
   
     const ast = flowParser.parse(scope.join("\n"));
@@ -98,8 +101,15 @@ describe("flow types", function () {
         visitProgram(path: any) {
           assert(path.scope.declaresType('Foo'));
           assert(path.scope.declaresType('Bar'));
+          assert(!path.scope.declaresType('OtherBar'));
+          assert(path.scope.declaresType('ImportedFoo'));
+          assert(path.scope.declaresType('ImportedBar'));
+          assert(path.scope.declaresType('ImportedBaz'));
           assert.equal(path.scope.lookupType('Foo').getTypes()['Foo'][0].parent.node.type, 'TypeAlias');
           assert.equal(path.scope.lookupType('Bar').getTypes()['Bar'][0].parent.node.type, 'InterfaceDeclaration');
+          assert.equal(path.scope.lookupType('ImportedFoo').getTypes()['ImportedFoo'][0].parent.node.type, 'ImportDefaultSpecifier');
+          assert.equal(path.scope.lookupType('ImportedBar').getTypes()['ImportedBar'][0].parent.node.type, 'ImportSpecifier');
+          assert.equal(path.scope.lookupType('ImportedBaz').getTypes()['ImportedBaz'][0].parent.node.type, 'ImportSpecifier');
           return false;
         }
       });


### PR DESCRIPTION
Previously, Flow `import type` specifiers would erroneously be counted as creating value bindings in a scope. With this change they are correctly added to `scopeTypes` instead.