### PR TITLE
Param may not exist in CatchClause, so do not addPattern when it doesn't

### DIFF
--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -173,7 +173,10 @@ export default function scopePlugin(fork: Fork) {
       // A catch clause establishes a new scope but the only variable
       // bound in that scope is the catch parameter. Any other
       // declarations create bindings in the outer scope.
-      addPattern(path.get("param"), bindings);
+      var param = path.get("param");
+      if (param.value !== null) {
+        addPattern(param, bindings);
+      }
 
     } else {
       recursiveScanScope(path, bindings, scopeTypes);


### PR DESCRIPTION
I'm not super familiar with AST work, so please advise if there is a better way to guard this condition. Basically when scanning scope, we always treat the param as being a pattern, when it is not a pattern in all cases (when it does not exist).