### PR TITLE
Rename prepack script to prepare, to allow installation from Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run gen && npm run build && npm run mocha",
     "clean": "ts-emit-clean",
     "build": "tsc && ts-add-module-exports",
-    "prepack": "npm run clean && npm run gen && npm run build",
+    "prepare": "npm run clean && npm run gen && npm run build",
     "postpack": "npm run clean"
   },
   "dependencies": {


### PR DESCRIPTION
When installing from Git, the `prepare` script is run [with `devDependencies` installed](https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts), while the `prepack` script is not. Fixes this error:

```
$ npm i benjamn/ast-types

> ast-types@0.14.2 prepack /home/anders/.npm/_cacache/tmp/git-clone-0fe11479
> npm run clean && npm run gen && npm run build

> ast-types@0.14.2 clean
> ts-emit-clean

sh: line 1: ts-emit-clean: command not found
npm ERR! code 127
```