### PR TITLE
scopes: support ObjectProperty in addPattern()

### DIFF
--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -318,8 +318,10 @@ export default function scopePlugin(fork: Fork) {
       namedTypes.AssignmentPattern.check(pattern)) {
       addPattern(patternPath.get('left'), bindings);
 
-    } else if (namedTypes.ObjectPattern &&
-      namedTypes.ObjectPattern.check(pattern)) {
+    } else if (
+      namedTypes.ObjectPattern &&
+      namedTypes.ObjectPattern.check(pattern)
+    ) {
       patternPath.get('properties').each(function(propertyPath: any) {
         var property = propertyPath.value;
         if (namedTypes.Pattern.check(property)) {
@@ -330,34 +332,44 @@ export default function scopePlugin(fork: Fork) {
            namedTypes.ObjectProperty.check(property))
         ) {
           addPattern(propertyPath.get('value'), bindings);
-        } else if (namedTypes.SpreadProperty &&
-          namedTypes.SpreadProperty.check(property)) {
+        } else if (
+          namedTypes.SpreadProperty &&
+          namedTypes.SpreadProperty.check(property)
+        ) {
           addPattern(propertyPath.get('argument'), bindings);
         }
       });
 
-    } else if (namedTypes.ArrayPattern &&
-      namedTypes.ArrayPattern.check(pattern)) {
+    } else if (
+      namedTypes.ArrayPattern &&
+      namedTypes.ArrayPattern.check(pattern)
+    ) {
       patternPath.get('elements').each(function(elementPath: any) {
         var element = elementPath.value;
         if (namedTypes.Pattern.check(element)) {
           addPattern(elementPath, bindings);
-        } else if (namedTypes.SpreadElement &&
-          namedTypes.SpreadElement.check(element)) {
+        } else if (
+          namedTypes.SpreadElement &&
+          namedTypes.SpreadElement.check(element)
+        ) {
           addPattern(elementPath.get("argument"), bindings);
         }
       });
 
-    } else if (namedTypes.PropertyPattern &&
-      namedTypes.PropertyPattern.check(pattern)) {
+    } else if (
+      namedTypes.PropertyPattern &&
+      namedTypes.PropertyPattern.check(pattern)
+    ) {
       addPattern(patternPath.get('pattern'), bindings);
 
-    } else if ((namedTypes.SpreadElementPattern &&
-      namedTypes.SpreadElementPattern.check(pattern)) ||
+    } else if (
+      (namedTypes.SpreadElementPattern &&
+       namedTypes.SpreadElementPattern.check(pattern)) ||
       (namedTypes.RestElement &&
-      namedTypes.RestElement.check(pattern)) ||
+       namedTypes.RestElement.check(pattern)) ||
       (namedTypes.SpreadPropertyPattern &&
-      namedTypes.SpreadPropertyPattern.check(pattern))) {
+       namedTypes.SpreadPropertyPattern.check(pattern))
+    ) {
       addPattern(patternPath.get('argument'), bindings);
     }
   }
@@ -372,7 +384,6 @@ export default function scopePlugin(fork: Fork) {
       } else {
         types[pattern.name] = [patternPath];
       }
-
     }
   }
 

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -324,8 +324,11 @@ export default function scopePlugin(fork: Fork) {
         var property = propertyPath.value;
         if (namedTypes.Pattern.check(property)) {
           addPattern(propertyPath, bindings);
-        } else  if (namedTypes.Property.check(property) ||
-          namedTypes.ObjectProperty.check(property)) {
+        } else if (
+          namedTypes.Property.check(property) ||
+          (namedTypes.ObjectProperty &&
+           namedTypes.ObjectProperty.check(property))
+        ) {
           addPattern(propertyPath.get('value'), bindings);
         } else if (namedTypes.SpreadProperty &&
           namedTypes.SpreadProperty.check(property)) {

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -324,7 +324,8 @@ export default function scopePlugin(fork: Fork) {
         var property = propertyPath.value;
         if (namedTypes.Pattern.check(property)) {
           addPattern(propertyPath, bindings);
-        } else  if (namedTypes.Property.check(property)) {
+        } else  if (namedTypes.Property.check(property) ||
+          namedTypes.ObjectProperty.check(property)) {
           addPattern(propertyPath.get('value'), bindings);
         } else if (namedTypes.SpreadProperty &&
           namedTypes.SpreadProperty.check(property)) {


### PR DESCRIPTION
This should fix an issue that we ran into using jscodeshift while using the `renameTo()` functionality. I noticed that the issue does not happen when using the default `babel` parser ([AST Explorer snippet](https://astexplorer.net/#/gist/8a4e8879cff65dbeda21098bd7776d17/a483790fbbe20e050f5ff9ad63687227628cd257)) but the issue does occur with the `tsx` or `babylon` parsers ([AST Explorer snippet](https://astexplorer.net/#/gist/8a4e8879cff65dbeda21098bd7776d17/4cc31b43fea756876ffab2e9d9e6d6b96404f83f)). 

The issue is that the Babel 7 configurations used in the `tsx` and `babylon` parsers use the `ObjectProperty` node type instead of `Property`, which is used by `flow` and older versions of Babel.