### PR TITLE
Add decorators to ClassDefinition (ES proposals)

### DIFF
--- a/def/es-proposals.ts
+++ b/def/es-proposals.ts
@@ -35,6 +35,11 @@ export default function (fork: Fork) {
            or([def("Decorator")], null),
            defaults["null"]);
 
+  def("ClassDeclaration")
+  .field("decorators",
+        or([def("Decorator")], null),
+        defaults["null"]);
+       
   // Private names
   def("PrivateName")
     .bases("Expression", "Pattern")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -915,6 +915,7 @@ export interface ClassDeclarationBuilder {
     params: {
       body: K.ClassBodyKind,
       comments?: K.CommentKind[] | null,
+      decorators?: K.DecoratorKind[] | null,
       id: K.IdentifierKind | null,
       implements?: K.ClassImplementsKind[] | K.TSExpressionWithTypeArgumentsKind[],
       loc?: K.SourceLocationKind | null,

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -450,6 +450,7 @@ export namespace namedTypes {
     id: K.IdentifierKind | null;
     body: K.ClassBodyKind;
     superClass?: K.ExpressionKind | null;
+    decorators?: K.DecoratorKind[] | null;
     typeParameters?: K.TypeParameterDeclarationKind | K.TSTypeParameterDeclarationKind | null;
     superTypeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null;
     implements?: K.ClassImplementsKind[] | K.TSExpressionWithTypeArgumentsKind[];


### PR DESCRIPTION
This PR adds `decorators` to `ClassDefinition`.

Although decorators are still a [stage 2 proposal](https://github.com/tc39/proposal-decorators), they are widely used and [supported by transpilers like jscodeshift](https://github.com/facebook/jscodeshift/issues/304).

Currently, it's not possible to manipulate class decorators in `jscodeshift` because the field is missing on `ClassDefinition`. 