### PR TITLE
Add importKind to ImportSpecifier (import {type MyType} from './types')

### DIFF
--- a/def/es6.ts
+++ b/def/es6.ts
@@ -216,11 +216,12 @@ export default function (fork: Fork) {
     .field("id", or(def("Identifier"), null), defaults["null"])
     .field("name", or(def("Identifier"), null), defaults["null"]);
 
-  // import {<id [as name]>} from ...;
+  // import {[type] <id [as name]>} from ...;
   def("ImportSpecifier")
     .bases("ModuleSpecifier")
-    .build("imported", "local")
-    .field("imported", def("Identifier"));
+    .build("imported", "local", "importKind")
+    .field("imported", def("Identifier"))
+    .field("importKind", or("type", null), defaults["null"]);
 
   // import <id> from ...;
   def("ImportDefaultSpecifier")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -952,11 +952,16 @@ export interface SuperBuilder {
 }
 
 export interface ImportSpecifierBuilder {
-  (imported: K.IdentifierKind, local?: K.IdentifierKind | null): namedTypes.ImportSpecifier;
+  (
+    imported: K.IdentifierKind,
+    local?: K.IdentifierKind | null,
+    importKind?: "type" | null
+  ): namedTypes.ImportSpecifier;
   from(
     params: {
       comments?: K.CommentKind[] | null,
       id?: K.IdentifierKind | null,
+      importKind?: "type" | null,
       imported: K.IdentifierKind,
       loc?: K.SourceLocationKind | null,
       local?: K.IdentifierKind | null,

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -476,6 +476,7 @@ export namespace namedTypes {
   export interface ImportSpecifier extends Omit<ModuleSpecifier, "type"> {
     type: "ImportSpecifier";
     imported: K.IdentifierKind;
+    importKind?: "type" | null;
   }
 
   export interface ImportDefaultSpecifier extends Omit<ModuleSpecifier, "type"> {


### PR DESCRIPTION
I'm working on a codemod to transform type imports into the new Typescript 4.5 syntax: https://github.com/facebook/jscodeshift/issues/481

I wanted to use `ImportSpecifierBuilder` to construct an import specifier that is a type import, but that was impossible.  I've never worked with ast-types before, so I'm not sure if I did this correctly.  And I was looking for tests to expand, but I couldn't find any `import type` style tests, so I'm not sure where it should go or what it would look like.  Any guidance would be much appreciated!