### PR TITLE
Add importKind to ImportSpecifier for Flow

### DIFF
--- a/def/flow.ts
+++ b/def/flow.ts
@@ -405,6 +405,9 @@ export default function (fork: Fork) {
   def("ImportDeclaration")
     .field("importKind", or("value", "type", "typeof"), () => "value");
 
+  def("ImportSpecifier")
+    .field("importKind", or("value", "type", "typeof"), () => "value");
+
   def("FlowPredicate").bases("Flow");
 
   def("InferredPredicate")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -957,6 +957,7 @@ export interface ImportSpecifierBuilder {
     params: {
       comments?: K.CommentKind[] | null,
       id?: K.IdentifierKind | null,
+      importKind?: "value" | "type" | "typeof",
       imported: K.IdentifierKind,
       loc?: K.SourceLocationKind | null,
       local?: K.IdentifierKind | null,

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -476,6 +476,7 @@ export namespace namedTypes {
   export interface ImportSpecifier extends Omit<ModuleSpecifier, "type"> {
     type: "ImportSpecifier";
     imported: K.IdentifierKind;
+    importKind?: "value" | "type" | "typeof";
   }
 
   export interface ImportDefaultSpecifier extends Omit<ModuleSpecifier, "type"> {


### PR DESCRIPTION
Flow accepts `type` or `typeof` on an individual import specifier, as
well as on the whole import statement.