### PR TITLE
Add "implements" to DeclareClass, for Flow `declare class`

### DIFF
--- a/def/flow.ts
+++ b/def/flow.ts
@@ -358,7 +358,8 @@ export default function (fork: Fork) {
 
   def("DeclareClass")
     .bases("InterfaceDeclaration")
-    .build("id");
+    .build("id")
+    .field("implements", [def("ClassImplements")], defaults.emptyArray);
 
   def("DeclareModule")
     .bases("Statement")

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -2294,6 +2294,7 @@ export interface DeclareClassBuilder {
       comments?: K.CommentKind[] | null,
       extends: K.InterfaceExtendsKind[],
       id: K.IdentifierKind,
+      implements?: K.ClassImplementsKind[],
       loc?: K.SourceLocationKind | null,
       typeParameters?: K.TypeParameterDeclarationKind | null
     }

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -1055,6 +1055,7 @@ export namespace namedTypes {
 
   export interface DeclareClass extends Omit<InterfaceDeclaration, "type"> {
     type: "DeclareClass";
+    implements?: K.ClassImplementsKind[];
   }
 
   export interface DeclareModule extends Omit<Statement, "type"> {


### PR DESCRIPTION
This is already produced by flow-parser to support Flow's
`declare class A implements B {}`.

At the moment it's ignored by the Recast printer, but I've sent a PR
to fix that, along with other features of `declare class`:
  https://github.com/benjamn/recast/pull/1090