### PR TITLE
fix(flow.ts): add importKind field to ImportSpecifier

### DIFF
--- a/def/flow.ts
+++ b/def/flow.ts
@@ -404,6 +404,9 @@ export default function (fork: Fork) {
 
   def("ImportDeclaration")
     .field("importKind", or("value", "type", "typeof"), () => "value");
+  
+  def("ImportSpecifier")
+    .field("importKind", or("value", "type", "typeof"), defaults["null"]);
 
   def("FlowPredicate").bases("Flow");
 

--- a/gen/builders.ts
+++ b/gen/builders.ts
@@ -580,7 +580,8 @@ export interface NewExpressionBuilder {
       callee: K.ExpressionKind,
       comments?: K.CommentKind[] | null,
       loc?: K.SourceLocationKind | null,
-      typeArguments?: null | K.TypeParameterInstantiationKind
+      typeArguments?: null | K.TypeParameterInstantiationKind,
+      typeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null
     }
   ): namedTypes.NewExpression;
 }
@@ -597,7 +598,8 @@ export interface CallExpressionBuilder {
       comments?: K.CommentKind[] | null,
       loc?: K.SourceLocationKind | null,
       optional?: boolean,
-      typeArguments?: null | K.TypeParameterInstantiationKind
+      typeArguments?: null | K.TypeParameterInstantiationKind,
+      typeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null
     }
   ): namedTypes.CallExpression;
 }
@@ -1194,7 +1196,8 @@ export interface OptionalCallExpressionBuilder {
       comments?: K.CommentKind[] | null,
       loc?: K.SourceLocationKind | null,
       optional?: boolean,
-      typeArguments?: null | K.TypeParameterInstantiationKind
+      typeArguments?: null | K.TypeParameterInstantiationKind,
+      typeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null
     }
   ): namedTypes.OptionalCallExpression;
 }

--- a/gen/namedTypes.ts
+++ b/gen/namedTypes.ts
@@ -298,6 +298,7 @@ export namespace namedTypes {
     type: "NewExpression";
     callee: K.ExpressionKind;
     arguments: (K.ExpressionKind | K.SpreadElementKind)[];
+    typeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null;
     typeArguments?: null | K.TypeParameterInstantiationKind;
   }
 
@@ -305,6 +306,7 @@ export namespace namedTypes {
     type: "CallExpression";
     callee: K.ExpressionKind;
     arguments: (K.ExpressionKind | K.SpreadElementKind)[];
+    typeParameters?: K.TypeParameterInstantiationKind | K.TSTypeParameterInstantiationKind | null;
     typeArguments?: null | K.TypeParameterInstantiationKind;
   }
 


### PR DESCRIPTION
```
> require('@babel/types').NODE_FIELDS.ImportSpecifier.importKind
{
  validate: [Function: validate] { oneOf: [ 'type', 'typeof', 'value' ] },
  optional: true,
  default: null
}
```