### PR TITLE
Make `assert` method an assertion function in TS

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,7 +27,7 @@ abstract class BaseType<T> {
 
   abstract check(value: any, deep?: Deep): value is T;
 
-  assert(value: any, deep?: Deep): value is T {
+  assert(value: any, deep?: Deep): asserts value is T {
     if (!this.check(value, deep)) {
       var str = shallowStringify(value);
       throw new Error(str + " does not match type " + this);


### PR DESCRIPTION
This is available since TS 3.7:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions

It could be considered a breaking change. Note that DefinitelyTyped supports officially only the last 2 years of TS releases and that makes 4.1 the last supported version there: https://github.com/DefinitelyTyped/DefinitelyTyped#support-window