### PR TITLE
Fix some missing fields for `ClassAccessorProperty` and related defs

### DIFF
--- a/src/def/babel-core.ts
+++ b/src/def/babel-core.ts
@@ -250,7 +250,7 @@ export default function (fork: Fork) {
       // Only when .computed is true (TODO enforce this)
       def("Expression"),
     ))
-    .field("value", def("Expression"));
+    .field("value", or(def("Expression"), null), defaults["null"]);
 
   ["ClassMethod",
    "ClassPrivateMethod",
@@ -272,7 +272,9 @@ export default function (fork: Fork) {
       .field("abstract", Boolean, defaults["false"])
       .field("accessibility", or("public", "private", "protected", null), defaults["null"])
       .field("decorators", or([def("Decorator")], null), defaults["null"])
+      .field("definite", Boolean, defaults["false"])
       .field("optional", Boolean, defaults["false"])
+      .field("override", Boolean, defaults["false"])
       .field("readonly", Boolean, defaults["false"]);
   });
 

--- a/src/gen/builders.ts
+++ b/src/gen/builders.ts
@@ -2770,6 +2770,7 @@ export interface ClassMethodBuilder {
       computed?: boolean;
       decorators?: K.DecoratorKind[] | null;
       defaults?: (K.ExpressionKind | null)[];
+      definite?: boolean;
       expression?: boolean;
       generator?: boolean;
       id?: K.IdentifierKind | null;
@@ -2777,6 +2778,7 @@ export interface ClassMethodBuilder {
       kind?: "get" | "set" | "method" | "constructor";
       loc?: K.SourceLocationKind | null;
       optional?: boolean;
+      override?: boolean;
       params: K.PatternKind[];
       predicate?: K.FlowPredicateKind | null;
       readonly?: boolean;
@@ -2808,6 +2810,7 @@ export interface ClassPrivateMethodBuilder {
       computed?: boolean;
       decorators?: K.DecoratorKind[] | null;
       defaults?: (K.ExpressionKind | null)[];
+      definite?: boolean;
       expression?: boolean;
       generator?: boolean;
       id?: K.IdentifierKind | null;
@@ -2815,6 +2818,7 @@ export interface ClassPrivateMethodBuilder {
       kind?: "get" | "set" | "method" | "constructor";
       loc?: K.SourceLocationKind | null;
       optional?: boolean;
+      override?: boolean;
       params: K.PatternKind[];
       predicate?: K.FlowPredicateKind | null;
       readonly?: boolean;
@@ -2829,7 +2833,7 @@ export interface ClassPrivateMethodBuilder {
 export interface ClassAccessorPropertyBuilder {
   (
     key: K.LiteralKind | K.IdentifierKind | K.PrivateNameKind | K.ExpressionKind,
-    value: K.ExpressionKind,
+    value?: K.ExpressionKind | null,
     decorators?: K.DecoratorKind[] | null,
     computed?: boolean,
     staticParam?: boolean
@@ -2841,13 +2845,15 @@ export interface ClassAccessorPropertyBuilder {
       comments?: K.CommentKind[] | null;
       computed?: boolean;
       decorators?: K.DecoratorKind[] | null;
+      definite?: boolean;
       key: K.LiteralKind | K.IdentifierKind | K.PrivateNameKind | K.ExpressionKind;
       loc?: K.SourceLocationKind | null;
       optional?: boolean;
+      override?: boolean;
       readonly?: boolean;
       static?: boolean;
       typeAnnotation?: K.TSTypeAnnotationKind | null;
-      value: K.ExpressionKind;
+      value?: K.ExpressionKind | null;
     }
   ): namedTypes.ClassAccessorProperty;
 }

--- a/src/gen/namedTypes.ts
+++ b/src/gen/namedTypes.ts
@@ -1287,7 +1287,9 @@ export namespace namedTypes {
     abstract?: boolean;
     accessibility?: "public" | "private" | "protected" | null;
     decorators?: K.DecoratorKind[] | null;
+    definite?: boolean;
     optional?: boolean;
+    override?: boolean;
     readonly?: boolean;
   }
 
@@ -1302,7 +1304,9 @@ export namespace namedTypes {
     abstract?: boolean;
     accessibility?: "public" | "private" | "protected" | null;
     decorators?: K.DecoratorKind[] | null;
+    definite?: boolean;
     optional?: boolean;
+    override?: boolean;
     readonly?: boolean;
   }
 
@@ -1313,13 +1317,15 @@ export namespace namedTypes {
   export interface ClassAccessorProperty extends Omit<Declaration, "type">, TSHasOptionalTypeAnnotation {
     type: "ClassAccessorProperty";
     key: K.LiteralKind | K.IdentifierKind | K.PrivateNameKind | K.ExpressionKind;
-    value: K.ExpressionKind;
+    value?: K.ExpressionKind | null;
     computed?: boolean;
     static?: boolean;
     abstract?: boolean;
     accessibility?: "public" | "private" | "protected" | null;
     decorators?: K.DecoratorKind[] | null;
+    definite?: boolean;
     optional?: boolean;
+    override?: boolean;
     readonly?: boolean;
   }
 


### PR DESCRIPTION
Now better aligned with [the Babel version](https://github.com/babel/babel/blob/362451b76439ea17308c392d8c782135de0823de/packages/babel-types/src/definitions/core.ts#L2265-L2344).

This should address https://github.com/benjamn/recast/pull/1232#issuecomment-1348870125, though I am beginning to see the value of @jedwards1211's proposal in #823 to handle Babel types using a more programmatic approach…