### PR TITLE
feat: add overrideDefs function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,11 @@ import babelDef from "./def/babel";
 import typescriptDef from "./def/typescript";
 import { ASTNode, Type, AnyType, Field } from "./types";
 import { NodePath } from "./node-path";
-import { namedTypes } from "./gen/namedTypes";
+import { namedTypes as baseNamedTypes } from "./gen/namedTypes";
 import { builders } from "./gen/builders";
 import { Visitor } from "./gen/visitor";
 
-const {
+let {
   astNodesAreEquivalent,
   builders,
   builtInTypes,
@@ -41,9 +41,32 @@ const {
   typescriptDef,
 ]);
 
+let namedTypes = baseNamedTypes;
+
 // Populate the exported fields of the namedTypes namespace, while still
 // retaining its member types.
 Object.assign(namedTypes, n);
+
+export function overrideDefs(defs: ReturnType<typeof fork>) {
+  astNodesAreEquivalent = defs.astNodesAreEquivalent;
+  builders = defs.builders;
+  builtInTypes = defs.builtInTypes;
+  defineMethod = defs.defineMethod;
+  eachField = defs.eachField;
+  finalize = defs.finalize;
+  getBuilderName = defs.getBuilderName;
+  getFieldNames = defs.getFieldNames;
+  getFieldValue = defs.getFieldValue;
+  getSupertypeNames = defs.getSupertypeNames;
+  namedTypes = defs.namedTypes;
+  NodePath = defs.NodePath;
+  Path = defs.Path;
+  PathVisitor = defs.PathVisitor;
+  someField = defs.someField;
+  Type = defs.Type;
+  use = defs.use;
+  visit = defs.visit;
+}
 
 export {
   AnyType,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import babelDef from "./def/babel";
 import typescriptDef from "./def/typescript";
 import { ASTNode, Type, AnyType, Field } from "./types";
 import { NodePath } from "./node-path";
-import { namedTypes as baseNamedTypes } from "./gen/namedTypes";
+import { namedTypes } from "./gen/namedTypes";
 import { builders } from "./gen/builders";
 import { Visitor } from "./gen/visitor";
 
@@ -41,8 +41,6 @@ let {
   typescriptDef,
 ]);
 
-let namedTypes = baseNamedTypes;
-
 // Populate the exported fields of the namedTypes namespace, while still
 // retaining its member types.
 Object.assign(namedTypes, n);
@@ -58,7 +56,7 @@ export function overrideDefs(defs: ReturnType<typeof fork>) {
   getFieldNames = defs.getFieldNames;
   getFieldValue = defs.getFieldValue;
   getSupertypeNames = defs.getSupertypeNames;
-  namedTypes = defs.namedTypes;
+  Object.assign(namedTypes, defs.namedTypes);
   NodePath = defs.NodePath;
   Path = defs.Path;
   PathVisitor = defs.PathVisitor;


### PR DESCRIPTION
Solving https://github.com/benjamn/recast/issues/1283 would be difficult because
it imports ast-types everywhere, and I would have to replace those references
with passing an ast-types fork as new function parameters all over the place.

This is the pragmatic solution, it would allow me to just replace all of the
ast-types exports with my own fork built from `@babel/types` (see
https://github.com/benjamn/ast-types/issues/823).  So anywhere that imports
them would get my definitions that are up-to-date with babel.

Building defs from `@babel/types` or other parsers' metadata is the only
sustainable option for the community to have a reliable codemod system built on recast.

