### PR TITLE
Fix some missing fields for ClassProperty and related defs

### DIFF
--- a/src/gen/builders.ts
+++ b/src/gen/builders.ts
@@ -878,6 +878,7 @@ export interface ClassPropertyBuilder {
       access?: "public" | "private" | "protected" | undefined;
       comments?: K.CommentKind[] | null;
       computed?: boolean;
+      decorators?: K.DecoratorKind[] | null;
       key: K.LiteralKind | K.IdentifierKind | K.ExpressionKind;
       loc?: K.SourceLocationKind | null;
       static?: boolean;

--- a/src/gen/namedTypes.ts
+++ b/src/gen/namedTypes.ts
@@ -433,6 +433,7 @@ export namespace namedTypes {
     typeAnnotation?: K.TypeAnnotationKind | K.TSTypeAnnotationKind | null;
     variance?: K.VarianceKind | "plus" | "minus" | null;
     access?: "public" | "private" | "protected" | undefined;
+    decorators?: K.DecoratorKind[] | null;
   }
 
   export interface StaticBlock extends Omit<Declaration, "type"> {


### PR DESCRIPTION
`decorators` exists as a property on `ClassProperty` https://astexplorer.net/#/gist/e9678bb04c77960533a9ffc6a3478ff6/4ef21be80f17f89cfac811f7e4e83fb230dc01bd.