### PR TITLE
fix: add typeArguments to CallExpression

### DIFF
--- a/src/def/typescript.ts
+++ b/src/def/typescript.ts
@@ -519,6 +519,9 @@ export default function (fork: Fork) {
       def("TSDeclareMethod"),
       TSTypeMember
     )]);
+
+  def("CallExpression")
+    .bases("TSHasOptionalTypeParameterInstantiation");
 };
 
 maybeSetModuleExports(() => module);

--- a/src/test/typescript.ts
+++ b/src/test/typescript.ts
@@ -407,5 +407,19 @@ glob("**/*.ts", {
         }
       });
     });
+
+    it("visits type parameters of call expressions", function () {
+      const program = babelParse([
+        "fn<T>(808)",
+      ].join("\n"), {
+        plugins: ["typescript"]
+      });
+
+      assertVisited(program, {
+        visitTSTypeParameterInstantiation(path) {
+          this.traverse(path);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds type parameters to `CallExpression` such that `visit` is able to visit them.